### PR TITLE
Allow disabling directory crawling for tests

### DIFF
--- a/doc/neotest.txt
+++ b/doc/neotest.txt
@@ -49,6 +49,9 @@ neotest.setup({user_config})                                 *neotest.setup()*
         diagnostic = {
           enabled = true
         },
+        discovery = {
+          enabled = true
+        },
         floating = {
           border = "rounded",
           max_height = 0.6,
@@ -133,12 +136,20 @@ neotest.Config                                                *neotest.Config*
 
     Fields: ~
         {adapters}   (neotest.Adapter[])
+        {discovery}  (neotest.Config.discovery)
         {icons}      (table<string, string>)
         {highlights} (table<string, string>)
         {floating}   (neotest.Config.floating)
         {strategies} (neotest.Config.strategies)
         {summary}    (neotest.Config.summary)
         {output}     (neotest.Config.output)
+
+
+neotest.Config.discovery                            *neotest.Config.discovery*
+
+
+    Fields: ~
+        {enabled} (boolean)
 
 
 neotest.Config.floating                              *neotest.Config.floating*

--- a/lua/neotest/config/init.lua
+++ b/lua/neotest/config/init.lua
@@ -17,12 +17,16 @@ vim.cmd([[
 
 ---@class neotest.Config
 ---@field adapters neotest.Adapter[]
+---@field discovery neotest.Config.discovery
 ---@field icons table<string, string>
 ---@field highlights table<string, string>
 ---@field floating neotest.Config.floating
 ---@field strategies neotest.Config.strategies
 ---@field summary neotest.Config.summary
 ---@field output neotest.Config.output
+--
+---@class neotest.Config.discovery
+---@field enabled boolean
 
 ---@class neotest.Config.floating
 ---@field border string: Border style
@@ -65,6 +69,9 @@ vim.cmd([[
 ---@type neotest.Config
 local default_config = {
   adapters = {},
+  discovery = {
+    enabled = true,
+  },
   icons = {
     passed = "✔",
     running = "🗘",

--- a/tests/unit/client/init_spec.lua
+++ b/tests/unit/client/init_spec.lua
@@ -136,6 +136,37 @@ describe("neotest client", function()
         assert.Not.same(file_tree:children(), {})
       end)
     end)
+
+    describe("discovery.enabled = false", function()
+      a.it("doesn't scan directories by default", function()
+        require("neotest.config").setup({
+          adapters = { mock_adapter },
+          discovery = { enabled = false },
+        })
+        local tree = client:get_position(dir)
+        assert.Nil(tree)
+        tree = client:get_position(dir .. "/test_file_1")
+        assert.Nil(tree)
+      end)
+
+      a.it("only scans buffers that are open when client starts", function()
+        require("neotest.config").setup({
+          adapters = { mock_adapter },
+          discovery = { enabled = false },
+        })
+        local bufnr = async.fn.bufadd(dir .. "/test_file_1")
+        async.fn.bufload(bufnr)
+        local tree = client:get_position(dir)
+        assert.Not.Nil(tree)
+        assert.Not.same(tree, {})
+        tree = client:get_position(dir .. "/test_file_1")
+        assert.Not.Nil(tree)
+        assert.Not.same(tree, {})
+        tree = client:get_position(dir .. "/test_file_2")
+        assert.Nil(tree)
+        async.api.nvim_buf_delete(bufnr, {})
+      end)
+    end)
   end)
 
   describe("running tests", function()


### PR DESCRIPTION
Intended to address #13

Relatively straightforward: adds a config option that, when disabled, doesn't call `_update_positions` on directories. Files still get populated in the summary on `BufOpen`/`BufWritePost`, and I also added some logic to scan the files that vim opens on start.

## Test plan

New functionality
- Set `discovery.enabled = false`
- Open a test file in a directory with multiple test files
- Observe that the test summary only displays the currently-open file

Nothing broke
- Set `discovery.enabled = true`
- Open a test file in a directory with multiple test files
- Observe that the test summary displays all discoverable tests, as per usual


## Future work
Per-directory configuration would still be a great addition. Another feature that could be cool is some test adapters are capable of running tests on a directory. It would be great if we could trigger a run on an entire directory without scanning it first, and then populate the summary based on the results. I may start looking into that next.