### PR TITLE
Enable position merging for more cases

### DIFF
--- a/lua/neotest/lib/positions/init.lua
+++ b/lua/neotest/lib/positions/init.lua
@@ -61,6 +61,17 @@ local function get_parent(position)
   }
 end
 
+---@param tree neotest.Tree
+---@return neotest.Tree
+local function wrap_with_parent(tree)
+  local parent = get_parent(tree:data())
+  local parent_tree = Tree.from_list({ parent }, function(pos)
+    return pos.id
+  end)
+  parent_tree:add_child(tree:data().id, tree)
+  return parent_tree
+end
+
 ---@param dir_tree neotest.Tree
 ---@param new_tree neotest.Tree
 ---@return neotest.Tree
@@ -133,7 +144,9 @@ end
 ---@param new neotest.Tree File or directory tree
 M.merge = function(orig, new)
   if not M.contains(orig:data(), new:data()) and not M.contains(new:data(), orig:data()) then
-    error("Common root not found")
+    while not M.contains(orig:data(), new:data()) do
+      orig = wrap_with_parent(orig)
+    end
   end
 
   local new_type = new:data().type

--- a/lua/neotest/lib/positions/init.lua
+++ b/lua/neotest/lib/positions/init.lua
@@ -91,12 +91,19 @@ local function replace_node(tree, node)
 
   -- Find parent node and replace child reference
   local parent = existing:parent()
-  if parent then
-    for i, child in pairs(parent._children) do
-      if node:data().id == child:data().id then
-        parent._children[i] = node
-        break
-      end
+  if not parent then
+    -- If there is no parent, then the tree describes the same position as node,
+    -- and is replaced in its entirety
+    tree._children = node._children
+    tree._nodes = node._nodes
+    tree._data = node._data
+    return
+  end
+
+  for i, child in pairs(parent._children) do
+    if node:data().id == child:data().id then
+      parent._children[i] = node
+      break
     end
   end
   node._parent = parent

--- a/lua/neotest/lib/positions/init.lua
+++ b/lua/neotest/lib/positions/init.lua
@@ -1,3 +1,5 @@
+local Path = require("plenary.path")
+local Tree = require("neotest.types").Tree
 local M = {}
 
 ---@param tree neotest.Tree
@@ -37,10 +39,55 @@ M.contains = function(parent, child)
   return parent.range[1] <= child.range[1] and parent.range[3] >= child.range[3]
 end
 
+---@param position neotest.Position
+---@return neotest.Position
+local function get_parent(position)
+  if position.type ~= "dir" and position.type ~= "file" then
+    error(string.format("Cannot get the parent of %s position", position.type))
+  end
+  if position.path == Path.path.root(position.path) then
+    return position
+  end
+  local pieces = vim.split(position.path, Path.path.sep)
+  table.remove(pieces)
+  local parent_path = table.concat(pieces, Path.path.sep)
+
+  return {
+    type = "dir",
+    id = parent_path,
+    path = parent_path,
+    name = pieces[#pieces],
+    range = nil,
+  }
+end
+
+---@param dir_tree neotest.Tree
+---@param new_tree neotest.Tree
+---@return neotest.Tree
+local function get_or_create_parent_node(dir_tree, new_tree)
+  local parent = get_parent(new_tree:data())
+  local parent_tree = dir_tree:get_key(parent.id)
+  if not parent_tree then
+    parent_tree = Tree.from_list({ parent }, function(pos)
+      return pos.id
+    end)
+    local grandparent_tree = get_or_create_parent_node(dir_tree, parent_tree)
+    grandparent_tree:add_child(new_tree:data().id, parent_tree)
+    parent_tree = dir_tree:get_key(parent.id)
+    assert(parent_tree ~= nil)
+  end
+  return parent_tree
+end
+
 ---@param tree neotest.Tree
 ---@param node neotest.Tree
 local function replace_node(tree, node)
   local existing = tree:get_key(node:data().id)
+  if not existing then
+    local parent = get_or_create_parent_node(tree, node)
+    parent:add_child(node:data().id, node)
+    return
+  end
 
   -- Find parent node and replace child reference
   local parent = existing:parent()
@@ -70,10 +117,7 @@ end
 ---@param file_tree neotest.Tree
 local function update_file_node(dir_tree, file_tree, force)
   local existing = dir_tree:get_key(file_tree:data().id)
-  if not existing then
-    error("File " .. file_tree:data().id .. " not in tree")
-  end
-  if force or (#existing:children() == 0 and #file_tree:children() > 0) then
+  if force or not existing or (#existing:children() == 0 and #file_tree:children() > 0) then
     replace_node(dir_tree, file_tree)
   end
 end

--- a/lua/neotest/types/tree.lua
+++ b/lua/neotest/types/tree.lua
@@ -69,6 +69,17 @@ end
 
 ---@parem key any
 ---@param tree neotest.Tree
+function Tree:add_child(key, tree)
+  local current = self:get_key(key)
+  if not current then
+    tree._parent = self
+    table.insert(self._children, tree)
+  end
+  self:set_key(key, tree)
+end
+
+---@parem key any
+---@param tree neotest.Tree
 function Tree:set_key(key, tree)
   local current = self:get_key(key)
 

--- a/tests/unit/lib/positions/init_spec.lua
+++ b/tests/unit/lib/positions/init_spec.lua
@@ -244,4 +244,37 @@ describe("merge", function()
     }
     assert.are.same(expected, ret:to_list())
   end)
+
+  it("merge(dir, file) adds new file", function()
+    local dir = create_tree({
+      { type = "dir", id = "/root", path = "/root" },
+    })
+    local file = create_tree({
+      { type = "file", id = "/root/file", path = "/root/file" },
+      { type = "test", id = "test-2", path = "/root/file" },
+    })
+    local ret = positions.merge(dir, file)
+    local expected = {
+      {
+        id = "/root",
+        path = "/root",
+        type = "dir",
+      },
+      {
+        {
+          id = "/root/file",
+          path = "/root/file",
+          type = "file",
+        },
+        {
+          {
+            id = "test-2",
+            path = "/root/file",
+            type = "test",
+          },
+        },
+      },
+    }
+    assert.are.same(expected, ret:to_list())
+  end)
 end)

--- a/tests/unit/lib/positions/init_spec.lua
+++ b/tests/unit/lib/positions/init_spec.lua
@@ -304,4 +304,41 @@ describe("merge", function()
     }
     assert.are.same(expected, ret:to_list())
   end)
+
+  it("merge(dir, dir) merges unrelated dirs at common ancestor", function()
+    local dir = create_tree({
+      { type = "dir", id = "/root/sub1", path = "/root/sub1" },
+      {
+        { type = "file", id = "/root/sub1/file", path = "/root/sub1/file" },
+        { { type = "test", id = "test-1", path = "/root/sub1/file" } },
+      },
+    })
+    local new_dir = create_tree({
+      { type = "dir", id = "/root/sub2", path = "/root/sub2" },
+      {
+        { type = "file", id = "/root/sub2/file", path = "/root/sub2/file" },
+        { { type = "test", id = "test-2", path = "/root/sub2/file" } },
+      },
+    })
+    local ret = positions.merge(dir, new_dir)
+    local expected = {
+      { type = "dir", id = "/root", name = "root", path = "/root" },
+      {
+        { type = "dir", id = "/root/sub1", path = "/root/sub1" },
+        {
+          { type = "file", id = "/root/sub1/file", path = "/root/sub1/file" },
+          { { type = "test", id = "test-1", path = "/root/sub1/file" } },
+        },
+      },
+      {
+        { type = "dir", id = "/root/sub2", path = "/root/sub2" },
+        {
+          { type = "file", id = "/root/sub2/file", path = "/root/sub2/file" },
+          { { type = "test", id = "test-2", path = "/root/sub2/file" } },
+        },
+      },
+    }
+    print(string.format("ret: %s", vim.inspect(ret:to_list())))
+    assert.are.same(expected, ret:to_list())
+  end)
 end)

--- a/tests/unit/lib/positions/init_spec.lua
+++ b/tests/unit/lib/positions/init_spec.lua
@@ -277,4 +277,31 @@ describe("merge", function()
     }
     assert.are.same(expected, ret:to_list())
   end)
+
+  it("merge(file, file) updates tests in file", function()
+    local file = create_tree({
+      { type = "file", id = "file", path = "/root/file" },
+      { { type = "test", id = "test-1", path = "/root/file" } },
+    })
+    local new_file = create_tree({
+      { type = "file", id = "file", path = "/root/file" },
+      { { type = "test", id = "test-2", path = "/root/file" } },
+    })
+    local ret = positions.merge(file, new_file)
+    local expected = {
+      {
+        id = "file",
+        path = "/root/file",
+        type = "file",
+      },
+      {
+        {
+          id = "test-2",
+          path = "/root/file",
+          type = "test",
+        },
+      },
+    }
+    assert.are.same(expected, ret:to_list())
+  end)
 end)

--- a/tests/unit/lib/positions/init_spec.lua
+++ b/tests/unit/lib/positions/init_spec.lua
@@ -1,0 +1,247 @@
+local positions = require("neotest.lib.positions")
+local Tree = require("neotest.types").Tree
+
+local function create_tree(positions)
+  return Tree.from_list(positions, function(pos)
+    return pos.id
+  end)
+end
+
+describe("contains", function()
+  it("dir contains file", function()
+    local dir = {
+      id = "a",
+      type = "dir",
+      name = "test",
+      path = "/neotest/test",
+      range = { 0, 0, 0, 0 },
+    }
+    local file = {
+      id = "b",
+      type = "file",
+      name = "other.lua",
+      path = "/neotest/test/other.lua",
+      range = { 0, 0, 0, 0 },
+    }
+    assert(positions.contains(dir, file))
+  end)
+
+  it("dir contains dir", function()
+    local dir = {
+      id = "a",
+      type = "dir",
+      name = "neotest",
+      path = "/neotest",
+      range = { 0, 0, 0, 0 },
+    }
+    local file = {
+      id = "b",
+      type = "dir",
+      name = "test",
+      path = "/neotest/test",
+      range = { 0, 0, 0, 0 },
+    }
+    assert(positions.contains(dir, file))
+  end)
+
+  it("file contains test", function()
+    local file = {
+      id = "a",
+      type = "file",
+      name = "test.lua",
+      path = "/test.lua",
+      range = { 0, 0, 10, 0 },
+    }
+    local test = {
+      id = "b",
+      type = "test",
+      name = "a_test",
+      path = "/test.lua",
+      range = { 3, 0, 5, 0 },
+    }
+    assert(positions.contains(file, test))
+  end)
+
+  it("dir doesn't contain file", function()
+    local dir = {
+      id = "a",
+      type = "dir",
+      name = "test",
+      path = "/neotest/test",
+      range = { 0, 0, 0, 0 },
+    }
+    local file = {
+      id = "b",
+      type = "file",
+      name = "test.lua",
+      path = "/neotest/other/test.lua",
+      range = { 0, 0, 0, 0 },
+    }
+    assert.Not(positions.contains(dir, file))
+  end)
+
+  it("dir doesn't contain dir", function()
+    local dir = {
+      id = "a",
+      type = "dir",
+      name = "neotest",
+      path = "/neotest/tests",
+      range = { 0, 0, 0, 0 },
+    }
+    local file = {
+      id = "b",
+      type = "dir",
+      name = "test",
+      path = "/neotest/client",
+      range = { 0, 0, 0, 0 },
+    }
+    assert.Not(positions.contains(dir, file))
+  end)
+
+  it("file doesn't contain test", function()
+    local file = {
+      id = "a",
+      type = "file",
+      name = "test.lua",
+      path = "/test.lua",
+      range = { 0, 0, 10, 0 },
+    }
+    local test = {
+      id = "b",
+      type = "test",
+      name = "a_test",
+      path = "/other_test.lua",
+      range = { 3, 0, 5, 0 },
+    }
+    assert.Not(positions.contains(file, test))
+  end)
+end)
+
+describe("merge", function()
+  it("merge(dir, file) replaces tests in existing file", function()
+    local dir = create_tree({
+      { type = "dir", id = "root", path = "/root" },
+      {
+        { type = "file", id = "file", path = "/root/file" },
+        { { type = "test", id = "test-1", path = "/root/file" } },
+      },
+    })
+    local file = create_tree({
+      { type = "file", id = "file", path = "/root/file" },
+      { type = "test", id = "test-2", path = "/root/file" },
+    })
+    local ret = positions.merge(dir, file)
+    local expected = {
+      {
+        id = "root",
+        path = "/root",
+        type = "dir",
+      },
+      {
+        {
+          id = "file",
+          path = "/root/file",
+          type = "file",
+        },
+        {
+          {
+            id = "test-2",
+            path = "/root/file",
+            type = "test",
+          },
+        },
+      },
+    }
+    assert.are.same(expected, ret:to_list())
+  end)
+
+  it("merge(dir, dir) replaces contents of dir", function()
+    local dir = create_tree({
+      { type = "dir", id = "root", path = "/root" },
+      {
+        { type = "file", id = "file", path = "/root/file" },
+        { { type = "test", id = "test-1", path = "/root/file" } },
+      },
+    })
+    local new_dir = create_tree({
+      { type = "dir", id = "root", path = "/root" },
+      {
+        { type = "file", id = "other", path = "/root/other" },
+        { { type = "test", id = "test-2", path = "/root/other" } },
+      },
+    })
+    local ret = positions.merge(dir, new_dir)
+    local expected = {
+      {
+        id = "root",
+        path = "/root",
+        type = "dir",
+      },
+      {
+        {
+          id = "other",
+          path = "/root/other",
+          type = "file",
+        },
+        {
+          {
+            id = "test-2",
+            path = "/root/other",
+            type = "test",
+          },
+        },
+      },
+    }
+    assert.are.same(expected, ret:to_list())
+  end)
+
+  it("merge(dir, dir) replaces contents of subdir", function()
+    local dir = create_tree({
+      { type = "dir", id = "root", path = "/root/sub" },
+      {
+        { type = "file", id = "file", path = "/root/sub/file" },
+        { { type = "test", id = "test-1", path = "/root/sub/file" } },
+      },
+    })
+    local new_dir = create_tree({
+      { type = "dir", id = "root", path = "/root" },
+      {
+        { type = "dir", id = "sub", path = "/root/sub" },
+        {
+          { type = "file", id = "file", path = "/root/sub/file" },
+          { { type = "test", id = "test-2", path = "/root/sub/file" } },
+        },
+      },
+    })
+    local ret = positions.merge(dir, new_dir)
+    local expected = {
+      {
+        id = "root",
+        path = "/root",
+        type = "dir",
+      },
+      {
+        {
+          id = "sub",
+          path = "/root/sub",
+          type = "dir",
+        },
+        {
+          {
+            id = "file",
+            path = "/root/sub/file",
+            type = "file",
+          },
+          {
+            {
+              id = "test-2",
+              path = "/root/sub/file",
+              type = "test",
+            },
+          },
+        },
+      },
+    }
+    assert.are.same(expected, ret:to_list())
+  end)
+end)

--- a/tests/unit/lib/positions/init_spec.lua
+++ b/tests/unit/lib/positions/init_spec.lua
@@ -338,7 +338,6 @@ describe("merge", function()
         },
       },
     }
-    print(string.format("ret: %s", vim.inspect(ret:to_list())))
     assert.are.same(expected, ret:to_list())
   end)
 end)


### PR DESCRIPTION
While debugging #30, I discovered that the reason tests weren't updating on save was because the root tree was a `type = 'file'`, and merging `type = 'file'` _into_ `type = 'file'` did not do anything.

This PR adds the following capabilities:
* Merging file into file works as expected
* Merging a _new_ file into a dir works (previously produced error)
* Merging two dirs with no common root joins them both under a new tree based at the common ancestor

I've added tests for everything, but let me know if there are other cases that you think should be covered.