### PR TITLE
Validate window before closing to avoid invalid window id errors

### DIFF
--- a/lua/neotest/lib/ui/float.lua
+++ b/lua/neotest/lib/ui/float.lua
@@ -76,6 +76,9 @@ function Float:close(force)
   if not force and api.nvim_get_current_win() == self.win_id then
     return false
   end
+  if not vim.api.nvim_win_is_valid(self.win_id) then
+    return true
+  end
   local buf = self:get_buf()
   pcall(api.nvim_win_close, self.win_id, true)
   for _, listener in pairs(self.listeners.close) do


### PR DESCRIPTION
The window that is going to be closed (via `win:close()` call)
probably have already been closed or no longer available, in which case
"Invalid window id" errors will occur when closing the window.

To avoid such an error, we can if the window is valid right before
closing the window.
