### PR TITLE
feat: streamed results

### DIFF
--- a/doc/neotest.txt
+++ b/doc/neotest.txt
@@ -76,7 +76,7 @@ neotest.setup({user_config})                                 *neotest.setup()*
           skipped = "NeotestSkipped",
           target = "NeotestTarget",
           test = "NeotestTest",
-          unknown = "NeotestUnknown",
+          unknown = "NeotestUnknown"
         },
         icons = {
           child_indent = "│",

--- a/lua/neotest/async.lua
+++ b/lua/neotest/async.lua
@@ -18,6 +18,25 @@ end
 local async_wrapper = {
   api = proxy_vim("api"),
   fn = proxy_vim("fn"),
+  lib = {
+    first = function(...)
+      local functions = { ... }
+      local send_ran, await_ran = plen_async.control.channel.oneshot()
+      local result, ran
+      for _, func in ipairs(functions) do
+        plen_async.run(function()
+          local func_result = func()
+          if not ran then
+            result = func_result
+            ran = true
+            send_ran()
+          end
+        end)
+      end
+      await_ran()
+      return result
+    end,
+  },
 }
 if false then
   -- For type checking

--- a/lua/neotest/client/state/init.lua
+++ b/lua/neotest/client/state/init.lua
@@ -61,15 +61,17 @@ function NeotestClientState:update_positions(adapter_id, tree)
 end
 
 ---@param results table<string, neotest.Result>
-function NeotestClientState:update_results(adapter_id, results)
+function NeotestClientState:update_results(adapter_id, results, partial)
   logger.debug("New results for adapter", adapter_id)
   logger.trace(results)
   self._results[adapter_id] = vim.tbl_extend("force", self._results[adapter_id] or {}, results)
   if not self._running[adapter_id] then
     self._running[adapter_id] = {}
   end
-  for id, _ in pairs(results) do
-    self._running[adapter_id][id] = nil
+  if not partial then
+    for id, _ in pairs(results) do
+      self._running[adapter_id][id] = nil
+    end
   end
   self._events:emit(NeotestEvents.RESULTS, adapter_id, results)
 end

--- a/lua/neotest/consumers/output.lua
+++ b/lua/neotest/consumers/output.lua
@@ -91,6 +91,9 @@ local client
 local init = function()
   if config.output.open_on_run then
     client.listeners.results = function(_, results)
+      if win then
+        return
+      end
       local cur_pos = async.fn.getpos(".")
       local line = cur_pos[2] - 1
       local buf_path = vim.fn.expand("%:p")

--- a/lua/neotest/types/fanout_accum.lua
+++ b/lua/neotest/types/fanout_accum.lua
@@ -1,0 +1,38 @@
+---Accumulates provided data and stores it, while sending to consumers.
+---Allows consuming all data ever pushed while subscribing at any point in time.
+---@class FanoutAccum
+---@field consumers fun(data: T)[]
+---@field data T | nil
+---@field accum fun(prev: T, new: any): T A function to combine previous data and new data
+local FanoutAccum = {}
+
+---@generic T
+---@param accum fun(prev: T, new: any): T
+---@param init T
+---@return FanoutAccum
+function FanoutAccum:new(accum, init)
+  self.__index = self
+  return setmetatable({
+    data = init,
+    accum = accum,
+    consumers = {},
+  }, self)
+end
+
+function FanoutAccum:subscribe(cb)
+  self.consumers[#self.consumers + 1] = cb
+  if self.data then
+    cb(self.data)
+  end
+end
+
+function FanoutAccum:push(data)
+  self.data = self.accum(self.data, data)
+  for _, cb in ipairs(self.consumers) do
+    cb(data)
+  end
+end
+
+return function(accum, init)
+  return FanoutAccum:new(accum, init)
+end

--- a/lua/neotest/types/init.lua
+++ b/lua/neotest/types/init.lua
@@ -16,11 +16,12 @@
 ---@field line? integer
 
 ---@class neotest.Process
----@field output async fun():string Output data
----@field is_complete fun(): boolean Is process complete
----@field result async fun(): integer Get result code of process (async)
+---@field output async fun()string Output data
+---@field is_complete fun() boolean Is process complete
+---@field result async fun() integer Get result code of process (async)
 ---@field attach async fun() Attach to the running process for user input
 ---@field stop async fun() Stop the running process
+---@field output_stream fun(): string | nil Async iterator of process output
 
 ---@alias neotest.Strategy async fun(spec: neotest.RunSpec): neotest.Process
 
@@ -39,6 +40,7 @@
 ---@field cwd? string
 ---@field context? table Arbitrary data to preserve state between running and result collection
 ---@field strategy? table Arguments for strategy
+---@field stream fun(output_stream: fun(): string[]): fun(): table<string, neotest.Result>
 
 ---@class neotest.ConsumerListeners
 ---@field discover_positions fun(adapter_id: string, path: string, tree: neotest.Tree)
@@ -54,5 +56,6 @@ local M = {}
 
 M.Tree = require("neotest.types.tree")
 M.FIFOQueue = require("neotest.types.queue")
+M.FanoutAccum = require("neotest.types.fanout_accum")
 
 return M

--- a/lua/neotest/types/init.lua
+++ b/lua/neotest/types/init.lua
@@ -16,12 +16,12 @@
 ---@field line? integer
 
 ---@class neotest.Process
----@field output async fun()string Output data
+---@field output async fun(): string Path to file containing output data
 ---@field is_complete fun() boolean Is process complete
 ---@field result async fun() integer Get result code of process (async)
 ---@field attach async fun() Attach to the running process for user input
 ---@field stop async fun() Stop the running process
----@field output_stream fun(): string | nil Async iterator of process output
+---@field output_stream async fun(): async fun(): string Async iterator of process output
 
 ---@alias neotest.Strategy async fun(spec: neotest.RunSpec): neotest.Process
 

--- a/tests/unit/client/strategies/integrated_spec.lua
+++ b/tests/unit/client/strategies/integrated_spec.lua
@@ -1,0 +1,73 @@
+local async = require("neotest.async")
+local a = async.tests
+local lib = require("neotest.lib")
+local strategy = require("neotest.client.strategies.integrated")
+
+A = function(...)
+  print(vim.inspect(...))
+end
+describe("integrated strategy", function()
+  a.it("produces output", function()
+    local process = strategy({
+      command = { "printf", "hello" },
+      strategy = {
+        height = 10,
+        width = 10,
+      },
+    })
+    process.result()
+    local output = lib.files.read(process.output())
+    assert.equal(output, "hello")
+  end)
+
+  a.it("returns exit code", function()
+    local process = strategy({
+      command = { "bash", "-c", "exit 100" },
+      strategy = {
+        height = 10,
+        width = 10,
+      },
+    })
+    local code = process.result()
+    assert.equal(code, 100)
+  end)
+
+  a.it("stops the job", function()
+    local process = strategy({
+      command = { "bash", "-c", "sleep 1" },
+      strategy = {
+        height = 10,
+        width = 10,
+      },
+    })
+    process.stop()
+    local code = process.result()
+    assert.Not.equal(0, code)
+  end)
+
+  a.it("streams output", function()
+    local process = strategy({
+      command = { "bash", "-c", "printf hello; sleep 0; printf world" },
+      strategy = {
+        height = 10,
+        width = 10,
+      },
+    })
+    local stream = process.output_stream()
+    assert.equal("hello", stream())
+    assert.equal("world", stream())
+  end)
+
+  a.it("opens attach window", function()
+    local process = strategy({
+      command = { "echo", "hello" },
+      strategy = {
+        height = 10,
+        width = 10,
+      },
+    })
+    async.util.sleep(100)
+    process.attach()
+    assert.Not.equal(async.api.nvim_win_get_config(0), "")
+  end)
+end)


### PR DESCRIPTION
Related discussion: https://github.com/nvim-neotest/neotest/discussions/48

This change allows for streaming results in 2 ways:
1. For adapters that break up the tree so run multiple processes, results for each process can be streamed so users can see it as separate processes rather than looking like one.
2. Adapters can provide a `stream` argument in the spec returned by `build_spec` which takes an async iterator over the lines of output data from the process and returns an iterator of results tables

The stream argument can look something like this
```lua
stream = function(data)
  return function()
    local lines = data()
    local results = {}
    for _, line in ipairs(lines) do
      local result = vim.json.decode(line, { luanil = { object = true } })
      results[result.id] = result.result
    end
    return results
  end
end,
```
I've gone with `stream` in the spec rather than a new adapter method to avoid issues with maintaining state across runs that use multiple processes.

Adapters don't need to consume the output iterator, for example for neotest-python I've implemented it by streaming results from the process to a file instead (see PR https://github.com/nvim-neotest/neotest-python/pull/12). I've added some library functions to assist with this. 

The iterators all operate on lists of lines of text because operating on raw text would require adapters to reimplement the same logic and iterating over line by line would require some kind of manual batching to avoid spamming the client consumers.

@stevearc @sidlatau 

Tagging adapter authors in case you are interested in implementing or have any comments
@olimorris @akinsho @haydenmeade @sidlatau @shunsambongi