### PR TITLE
feat: add config option to specify default strategy

### DIFF
--- a/doc/neotest.txt
+++ b/doc/neotest.txt
@@ -154,7 +154,7 @@ neotest.Config                                                *neotest.Config*
         {icons}            (table<string, string>)
         {highlights}       (table<string, string>)
         {floating}         (neotest.Config.floating)
-        {default_strategy} (string)
+        {default_strategy} (string|function)
         {strategies}       (neotest.Config.strategies)
         {summary}          (neotest.Config.summary)
         {output}           (neotest.Config.output)

--- a/doc/neotest.txt
+++ b/doc/neotest.txt
@@ -47,6 +47,7 @@ neotest.setup({user_config})                                 *neotest.setup()*
       {
         adapters = {},
         consumers = {},
+        default_strategy = "integrated",
         diagnostic = {
           enabled = true
         },
@@ -147,16 +148,17 @@ neotest.Config                                                *neotest.Config*
 
 
     Fields: ~
-        {adapters}   (neotest.Adapter[])
-        {consumers}  (table<string, neotest.Consumer>)
-        {discovery}  (neotest.Config.discovery)
-        {icons}      (table<string, string>)
-        {highlights} (table<string, string>)
-        {floating}   (neotest.Config.floating)
-        {strategies} (neotest.Config.strategies)
-        {summary}    (neotest.Config.summary)
-        {output}     (neotest.Config.output)
-        {status}     (neotest.Config.status)
+        {adapters}         (neotest.Adapter[])
+        {consumers}        (table<string, neotest.Consumer>)
+        {discovery}        (neotest.Config.discovery)
+        {icons}            (table<string, string>)
+        {highlights}       (table<string, string>)
+        {floating}         (neotest.Config.floating)
+        {default_strategy} (string)
+        {strategies}       (neotest.Config.strategies)
+        {summary}          (neotest.Config.summary)
+        {output}           (neotest.Config.output)
+        {status}           (neotest.Config.status)
 
 
 neotest.Config.discovery                            *neotest.Config.discovery*

--- a/lua/neotest/client/runner.lua
+++ b/lua/neotest/client/runner.lua
@@ -55,7 +55,7 @@ function TestRunner:run_tree(tree, args, adapter, on_results)
     on_results(results)
   end
 
-  args = vim.tbl_extend("keep", args or {}, { strategy = "integrated" })
+  args = vim.tbl_extend("keep", args or {}, { strategy = config.default_strategy })
 
   self:_run_tree(tree, args, adapter, results_callback)
 

--- a/lua/neotest/config/init.lua
+++ b/lua/neotest/config/init.lua
@@ -26,7 +26,7 @@ vim.cmd([[
 ---@field icons table<string, string>
 ---@field highlights table<string, string>
 ---@field floating neotest.Config.floating
----@field default_strategy string
+---@field default_strategy string | function
 ---@field strategies neotest.Config.strategies
 ---@field summary neotest.Config.summary
 ---@field output neotest.Config.output

--- a/lua/neotest/config/init.lua
+++ b/lua/neotest/config/init.lua
@@ -26,6 +26,7 @@ vim.cmd([[
 ---@field icons table<string, string>
 ---@field highlights table<string, string>
 ---@field floating neotest.Config.floating
+---@field default_strategy string
 ---@field strategies neotest.Config.strategies
 ---@field summary neotest.Config.summary
 ---@field output neotest.Config.output
@@ -125,6 +126,7 @@ local default_config = {
     max_width = 0.6,
     options = {},
   },
+  default_strategy = "integrated",
   strategies = {
     integrated = {
       width = 120,


### PR DESCRIPTION
I've written [a custom neotest strategy](https://github.com/stevearc/overseer.nvim/blob/master/lua/neotest/client/strategies/overseer.lua) and I'd like to use it by default. I tested both by setting the `default_strategy` and leaving it empty in the call to `setup()`, and both cases work as expected.