### PR TITLE
[RFC] Delay setting file type of summary buffers

### DIFF
--- a/ftplugin/neotest-summary.vim
+++ b/ftplugin/neotest-summary.vim
@@ -1,1 +1,17 @@
-setlocal nomodifiable norelativenumber nonumber winfixwidth nospell
+if get(b:, 'did_ftplugin', v:false)
+	finish
+endif
+let b:did_ftplugin = v:true
+
+let s:save_cpo = &cpo
+set cpo&vim
+
+setlocal winfixwidth
+setlocal nonumber
+setlocal norelativenumber
+setlocal nospell
+
+let b:undo_ftplugin = 'setlocal wfh< nu< rnu< spell<'
+
+let &cpo = s:save_cpo
+unlet s:save_cpo

--- a/ftplugin/neotest-summary.vim
+++ b/ftplugin/neotest-summary.vim
@@ -1,0 +1,1 @@
+setlocal nomodifiable norelativenumber nonumber winfixwidth nospell

--- a/lua/neotest/consumers/summary/init.lua
+++ b/lua/neotest/consumers/summary/init.lua
@@ -16,6 +16,7 @@ local function create_buf()
   end
 
   summary_buf = async.api.nvim_create_buf(false, true)
+  async.api.nvim_buf_set_option(summary_buf, 'modifiable', false)
   async.api.nvim_buf_set_name(summary_buf, buf_name)
   return summary_buf
 end

--- a/lua/neotest/consumers/summary/init.lua
+++ b/lua/neotest/consumers/summary/init.lua
@@ -16,13 +16,6 @@ local function create_buf()
   end
 
   summary_buf = async.api.nvim_create_buf(false, true)
-  local options = {
-    modifiable = false,
-    filetype = "neotest-summary",
-  }
-  for name, value in pairs(options) do
-    async.api.nvim_buf_set_option(summary_buf, name, value)
-  end
   async.api.nvim_buf_set_name(summary_buf, buf_name)
   return summary_buf
 end
@@ -35,16 +28,9 @@ local function open_window(buf)
   local cur_win = async.api.nvim_get_current_win()
   vim.cmd([[botright vsplit | vertical resize 50]])
   local win = async.api.nvim_get_current_win()
-  local options = {
-    relativenumber = false,
-    number = false,
-    winfixwidth = true,
-  }
-  for name, value in pairs(options) do
-    async.api.nvim_win_set_option(win, name, value)
-  end
   async.api.nvim_win_set_buf(win, buf)
   async.api.nvim_set_current_win(cur_win)
+  async.api.nvim_buf_set_option(summary_buf, 'filetype', 'neotest-summary')
 end
 
 local components = {}


### PR DESCRIPTION
The standard Vim way of setting filetype-specific settings is to add them to an `ftplugin/my-filetype.{vim,lua}` file (`:h ftplugin`), but this does not in Neotest work with window-specific options like `'spell'`. The solution was to delay setting the file type until after the window exists. While at it I also moved the default settings to a dedicated file to save some lines of code and I added the `nospell` setting because I think we should have that as a default.

Personally I would remove the `norelativenumber` setting from the defaults because we already have `nonumber` in the defaults. If users want to turn numbers back on we should not be forcing absolute numbers on them. What is your opinion?