### PR TITLE
feat(output): open output for last test run

### DIFF
--- a/doc/neotest.txt
+++ b/doc/neotest.txt
@@ -319,6 +319,7 @@ window will be used
 {short} `(boolean)` Show shortened output
 {enter} `(boolean)` Enter output window
 {quiet} `(boolean)` Suppress warnings of no output
+{last_run} `(boolean)` Open output for last test run
 {position_id} `(string)` Open output for position with this ID, opens nearest
 position if not given
 {adapter} `(string)` Adapter ID, defaults to first found with matching position
@@ -418,6 +419,12 @@ chosen position is used.
 neotest.run.adapters()                                  *neotest.run.adapters()*
                             `neotest.run.adapters`()
 Get the list of all known adapter IDs.
+
+neotest.run.get_last_run()                          *neotest.run.get_last_run()*
+                          `neotest.run.get_last_run`()
+Get last test run tree and adapter id.
+Return~
+neotest.Tree | `(nil,)` integer | nil
 
 
 ==============================================================================

--- a/doc/neotest.txt
+++ b/doc/neotest.txt
@@ -424,7 +424,7 @@ neotest.run.get_last_run()                          *neotest.run.get_last_run()*
                           `neotest.run.get_last_run`()
 Get last test run tree and adapter id.
 Return~
-neotest.Tree | `(nil,)` integer | nil
+`(string)` | nil, table | nil Position id and last args table
 
 
 ==============================================================================

--- a/lua/neotest/consumers/output.lua
+++ b/lua/neotest/consumers/output.lua
@@ -174,7 +174,10 @@ function neotest.output.open(opts)
   async.run(function()
     local tree, adapter_id
     if opts.last_run then
-      tree, adapter_id = run.get_last_run()
+      local position_id, last_args = run.get_last_run()
+      if position_id and last_args then
+        tree, adapter_id = client:get_position(position_id, last_args)
+      end
       if not tree then
         lib.notify("Last test run no longer exists")
         return

--- a/lua/neotest/consumers/output.lua
+++ b/lua/neotest/consumers/output.lua
@@ -1,7 +1,6 @@
 local async = require("neotest.async")
 local lib = require("neotest.lib")
 local config = require("neotest.config")
-local run = require("neotest").run
 
 local win, short_opened
 
@@ -174,7 +173,7 @@ function neotest.output.open(opts)
   async.run(function()
     local tree, adapter_id
     if opts.last_run then
-      local position_id, last_args = run.get_last_run()
+      local position_id, last_args = require("neotest").run.get_last_run()
       if position_id and last_args then
         tree, adapter_id = client:get_position(position_id, last_args)
       end

--- a/lua/neotest/consumers/output.lua
+++ b/lua/neotest/consumers/output.lua
@@ -1,6 +1,7 @@
 local async = require("neotest.async")
 local lib = require("neotest.lib")
 local config = require("neotest.config")
+local run = require("neotest").run
 
 local win, short_opened
 
@@ -154,6 +155,7 @@ end
 ---@field short boolean Show shortened output
 ---@field enter boolean Enter output window
 ---@field quiet boolean Suppress warnings of no output
+---@field last_run boolean Open output for last test run
 ---@field position_id string Open output for position with this ID, opens nearest
 --- position if not given
 ---@field adapter string Adapter ID, defaults to first found with matching position
@@ -171,7 +173,13 @@ function neotest.output.open(opts)
   end
   async.run(function()
     local tree, adapter_id
-    if not opts.position_id then
+    if opts.last_run then
+      tree, adapter_id = run.get_last_run()
+      if not tree then
+        lib.notify("Last test run no longer exists")
+        return
+      end
+    elseif not opts.position_id then
       local file_path = vim.fn.expand("%:p")
       local row = vim.fn.getbufinfo(file_path)[1].lnum - 1
       tree, adapter_id = client:get_nearest(file_path, row, opts)

--- a/lua/neotest/consumers/run.lua
+++ b/lua/neotest/consumers/run.lua
@@ -198,13 +198,12 @@ function neotest.run.adapters()
 end
 
 --- Get last test run tree and adapter id.
----@return neotest.Tree | nil, integer | nil
+---@return string | nil, table | nil Position id and last args table
 function neotest.run.get_last_run()
   if not last_run then
-    return
+    return nil, nil
   end
-  local position_id, last_args = unpack(last_run)
-  return client:get_position(position_id, last_args)
+  return unpack(last_run)
 end
 
 neotest.run = setmetatable(neotest.run, {

--- a/lua/neotest/consumers/run.lua
+++ b/lua/neotest/consumers/run.lua
@@ -197,6 +197,16 @@ function neotest.run.adapters()
   return client:get_adapters()
 end
 
+--- Get last test run tree and adapter id.
+---@return neotest.Tree | nil, integer | nil
+function neotest.run.get_last_run()
+  if not last_run then
+    return
+  end
+  local position_id, last_args = unpack(last_run)
+  return client:get_position(position_id, last_args)
+end
+
 neotest.run = setmetatable(neotest.run, {
   __call = function(_, client_)
     client = client_


### PR DESCRIPTION
Running `:lua require('neotest').output.open({ last_run = true })` will open output of last test run. 

I created this to support the workflow:

- Run a test with `:lua require("neotest").run.run()`.
- Edit implementation in a split, next to the test file.
- Run `:lua require("neotest").run.run_last()` to run last test while still in non-test buffer.
- Run `:lua require('neotest').output.open({ last_run = true })` to check it's output still in the non-test buffer.

Should not be feature creep, so if there's a better way to support this workflow, let me know!