### PR TITLE
feat(consumers): add state consumer (statusbar integration)

### DIFF
--- a/lua/neotest/config/init.lua
+++ b/lua/neotest/config/init.lua
@@ -2,7 +2,7 @@
 ---@toc_entry Configuration Options
 
 local function define_highlights()
-  vim.cmd([[
+	vim.cmd([[
   hi default NeotestPassed ctermfg=Green guifg=#96F291
   hi default NeotestFailed ctermfg=Red guifg=#F70067
   hi default NeotestRunning ctermfg=Yellow guifg=#FFEC63
@@ -109,122 +109,125 @@ define_highlights()
 ---@private
 ---@type neotest.Config
 local default_config = {
-  log_level = vim.log.levels.WARN,
-  adapters = {},
-  discovery = {
-    enabled = true,
-    concurrent = 0,
-    filter_dir = nil,
-  },
-  running = {
-    concurrent = true,
-  },
-  consumers = {},
-  icons = {
-    -- Ascii:
-    -- { "/", "|", "\\", "-", "/", "|", "\\", "-"},
-    -- Unicode:
-    -- { "", "🞅", "🞈", "🞉", "", "", "🞉", "🞈", "🞅", "", },
-    -- {"◴" ,"◷" ,"◶", "◵"},
-    -- {"◢", "◣", "◤", "◥"},
-    -- {"◐", "◓", "◑", "◒"},
-    -- {"◰", "◳", "◲", "◱"},
-    -- {"⣾", "⣽", "⣻", "⢿", "⡿", "⣟", "⣯", "⣷"},
-    -- {"⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"},
-    -- {"⠋", "⠙", "⠚", "⠞", "⠖", "⠦", "⠴", "⠲", "⠳", "⠓"},
-    -- {"⠄", "⠆", "⠇", "⠋", "⠙", "⠸", "⠰", "⠠", "⠰", "⠸", "⠙", "⠋", "⠇", "⠆"},
-    -- { "⠋", "⠙", "⠚", "⠒", "⠂", "⠂", "⠒", "⠲", "⠴", "⠦", "⠖", "⠒", "⠐", "⠐", "⠒", "⠓", "⠋" },
-    running_animated = { "/", "|", "\\", "-", "/", "|", "\\", "-" },
-    passed = "",
-    running = "",
-    failed = "",
-    skipped = "",
-    unknown = "",
-    non_collapsible = "─",
-    collapsed = "─",
-    expanded = "╮",
-    child_prefix = "├",
-    final_child_prefix = "╰",
-    child_indent = "│",
-    final_child_indent = " ",
-  },
-  highlights = {
-    passed = "NeotestPassed",
-    running = "NeotestRunning",
-    failed = "NeotestFailed",
-    skipped = "NeotestSkipped",
-    test = "NeotestTest",
-    namespace = "NeotestNamespace",
-    focused = "NeotestFocused",
-    file = "NeotestFile",
-    dir = "NeotestDir",
-    border = "NeotestBorder",
-    indent = "NeotestIndent",
-    expand_marker = "NeotestExpandMarker",
-    adapter_name = "NeotestAdapterName",
-    select_win = "NeotestWinSelect",
-    marked = "NeotestMarked",
-    target = "NeotestTarget",
-    unknown = "NeotestUnknown",
-  },
-  floating = {
-    border = "rounded",
-    max_height = 0.6,
-    max_width = 0.6,
-    options = {},
-  },
-  default_strategy = "integrated",
-  strategies = {
-    integrated = {
-      width = 120,
-      height = 40,
-    },
-  },
-  summary = {
-    enabled = true,
-    animated = true,
-    follow = true,
-    expand_errors = true,
-    mappings = {
-      expand = { "<CR>", "<2-LeftMouse>" },
-      expand_all = "e",
-      output = "o",
-      short = "O",
-      attach = "a",
-      jumpto = "i",
-      stop = "u",
-      run = "r",
-      mark = "m",
-      run_marked = "R",
-      clear_marked = "M",
-      target = "t",
-      clear_target = "T",
-      next_failed = "J",
-      prev_failed = "K",
-    },
-  },
-  benchmark = {
-    enabled = true,
-  },
-  output = {
-    enabled = true,
-    open_on_run = "short",
-  },
-  diagnostic = {
-    enabled = true,
-  },
-  status = {
-    enabled = true,
-    virtual_text = false,
-    signs = true,
-  },
-  run = {
-    enabled = true,
-  },
-  jump = {
-    enabled = true,
-  },
-  projects = {},
+	log_level = vim.log.levels.WARN,
+	adapters = {},
+	discovery = {
+		enabled = true,
+		concurrent = 0,
+		filter_dir = nil,
+	},
+	running = {
+		concurrent = true,
+	},
+	consumers = {},
+	icons = {
+		-- Ascii:
+		-- { "/", "|", "\\", "-", "/", "|", "\\", "-"},
+		-- Unicode:
+		-- { "", "🞅", "🞈", "🞉", "", "", "🞉", "🞈", "🞅", "", },
+		-- {"◴" ,"◷" ,"◶", "◵"},
+		-- {"◢", "◣", "◤", "◥"},
+		-- {"◐", "◓", "◑", "◒"},
+		-- {"◰", "◳", "◲", "◱"},
+		-- {"⣾", "⣽", "⣻", "⢿", "⡿", "⣟", "⣯", "⣷"},
+		-- {"⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"},
+		-- {"⠋", "⠙", "⠚", "⠞", "⠖", "⠦", "⠴", "⠲", "⠳", "⠓"},
+		-- {"⠄", "⠆", "⠇", "⠋", "⠙", "⠸", "⠰", "⠠", "⠰", "⠸", "⠙", "⠋", "⠇", "⠆"},
+		-- { "⠋", "⠙", "⠚", "⠒", "⠂", "⠂", "⠒", "⠲", "⠴", "⠦", "⠖", "⠒", "⠐", "⠐", "⠒", "⠓", "⠋" },
+		running_animated = { "/", "|", "\\", "-", "/", "|", "\\", "-" },
+		passed = "",
+		running = "",
+		failed = "",
+		skipped = "",
+		unknown = "",
+		non_collapsible = "─",
+		collapsed = "─",
+		expanded = "╮",
+		child_prefix = "├",
+		final_child_prefix = "╰",
+		child_indent = "│",
+		final_child_indent = " ",
+	},
+	highlights = {
+		passed = "NeotestPassed",
+		running = "NeotestRunning",
+		failed = "NeotestFailed",
+		skipped = "NeotestSkipped",
+		test = "NeotestTest",
+		namespace = "NeotestNamespace",
+		focused = "NeotestFocused",
+		file = "NeotestFile",
+		dir = "NeotestDir",
+		border = "NeotestBorder",
+		indent = "NeotestIndent",
+		expand_marker = "NeotestExpandMarker",
+		adapter_name = "NeotestAdapterName",
+		select_win = "NeotestWinSelect",
+		marked = "NeotestMarked",
+		target = "NeotestTarget",
+		unknown = "NeotestUnknown",
+	},
+	floating = {
+		border = "rounded",
+		max_height = 0.6,
+		max_width = 0.6,
+		options = {},
+	},
+	default_strategy = "integrated",
+	strategies = {
+		integrated = {
+			width = 120,
+			height = 40,
+		},
+	},
+	summary = {
+		enabled = true,
+		animated = true,
+		follow = true,
+		expand_errors = true,
+		mappings = {
+			expand = { "<CR>", "<2-LeftMouse>" },
+			expand_all = "e",
+			output = "o",
+			short = "O",
+			attach = "a",
+			jumpto = "i",
+			stop = "u",
+			run = "r",
+			mark = "m",
+			run_marked = "R",
+			clear_marked = "M",
+			target = "t",
+			clear_target = "T",
+			next_failed = "J",
+			prev_failed = "K",
+		},
+	},
+	benchmark = {
+		enabled = true,
+	},
+	output = {
+		enabled = true,
+		open_on_run = "short",
+	},
+	diagnostic = {
+		enabled = true,
+	},
+	status = {
+		enabled = true,
+		virtual_text = false,
+		signs = true,
+	},
+	run = {
+		enabled = true,
+	},
+	jump = {
+		enabled = true,
+	},
+	state = {
+		enabled = true,
+	},
+	projects = {},
 }
 
 local user_config = default_config
@@ -234,71 +237,71 @@ local user_config = default_config
 local NeotestConfigModule = {}
 
 local convert_concurrent = function(val)
-  if val == 0 or val == true then
-    return #vim.loop.cpu_info() + 4
-  end
-  if val == false then
-    return 1
-  end
-  assert(type(val) == "number", "concurrent must be a boolean or a number")
-  return val
+	if val == 0 or val == true then
+		return #vim.loop.cpu_info() + 4
+	end
+	if val == false then
+		return 1
+	end
+	assert(type(val) == "number", "concurrent must be a boolean or a number")
+	return val
 end
 
 ---@param config neotest.Config
 ---@private
 function NeotestConfigModule.setup(config)
-  ---@type neotest.Config
-  user_config = vim.tbl_deep_extend("force", default_config, config)
-  --- Avoid mutating default for docgen
-  user_config.discovery = vim.tbl_deep_extend(
-    "force",
-    user_config.discovery,
-    { concurrent = convert_concurrent(user_config.discovery.concurrent) }
-  )
+	---@type neotest.Config
+	user_config = vim.tbl_deep_extend("force", default_config, config)
+	--- Avoid mutating default for docgen
+	user_config.discovery = vim.tbl_deep_extend(
+		"force",
+		user_config.discovery,
+		{ concurrent = convert_concurrent(user_config.discovery.concurrent) }
+	)
 
-  user_config.projects = setmetatable({}, {
-    __index = function()
-      return user_config
-    end,
-  })
-  for project_root, project_config in pairs(config.projects or {}) do
-    NeotestConfigModule.setup_project(project_root, project_config)
-  end
+	user_config.projects = setmetatable({}, {
+		__index = function()
+			return user_config
+		end,
+	})
+	for project_root, project_config in pairs(config.projects or {}) do
+		NeotestConfigModule.setup_project(project_root, project_config)
+	end
 
-  local logger = require("neotest.logging")
-  logger:set_level(user_config.log_level)
-  logger.info("Configuration complete")
-  logger.debug("User config", user_config)
+	local logger = require("neotest.logging")
+	logger:set_level(user_config.log_level)
+	logger.info("Configuration complete")
+	logger.debug("User config", user_config)
 end
 
 function NeotestConfigModule.setup_project(project_root, config)
-  local path = vim.fn.fnamemodify(project_root, ":p")
-  path = path:sub(1, #path - 1) -- Trailing slash
-  user_config.projects[path] = vim.tbl_deep_extend("keep", config, {
-    adapters = user_config.adapters,
-    discovery = user_config.discovery,
-    running = user_config.running,
-  })
-  user_config.projects[path].discovery.concurrent =
-    convert_concurrent(user_config.projects[path].discovery.concurrent)
-  local logger = require("neotest.logging")
-  logger.info("Project", path, "configuration complete")
-  logger.debug("Project config", user_config.projects[path])
+	local path = vim.fn.fnamemodify(project_root, ":p")
+	path = path:sub(1, #path - 1) -- Trailing slash
+	user_config.projects[path] = vim.tbl_deep_extend("keep", config, {
+		adapters = user_config.adapters,
+		discovery = user_config.discovery,
+		running = user_config.running,
+	})
+	user_config.projects[path].discovery.concurrent =
+	convert_concurrent(user_config.projects[path].discovery.concurrent)
+	local logger = require("neotest.logging")
+	logger.info("Project", path, "configuration complete")
+	logger.debug("Project config", user_config.projects[path])
 end
 
 function NeotestConfigModule._format_default()
-  local lines = { "Default values:", ">" }
-  for line in vim.gsplit(vim.inspect(default_config), "\n", true) do
-    table.insert(lines, "  " .. line)
-  end
-  table.insert(lines, "<")
-  return lines
+	local lines = { "Default values:", ">" }
+	for line in vim.gsplit(vim.inspect(default_config), "\n", true) do
+		table.insert(lines, "  " .. line)
+	end
+	table.insert(lines, "<")
+	return lines
 end
 
 setmetatable(NeotestConfigModule, {
-  __index = function(_, key)
-    return user_config[key]
-  end,
+	__index = function(_, key)
+		return user_config[key]
+	end,
 })
 
 return NeotestConfigModule

--- a/lua/neotest/config/init.lua
+++ b/lua/neotest/config/init.lua
@@ -2,7 +2,7 @@
 ---@toc_entry Configuration Options
 
 local function define_highlights()
-	vim.cmd([[
+  vim.cmd([[
   hi default NeotestPassed ctermfg=Green guifg=#96F291
   hi default NeotestFailed ctermfg=Red guifg=#F70067
   hi default NeotestRunning ctermfg=Yellow guifg=#FFEC63
@@ -109,125 +109,125 @@ define_highlights()
 ---@private
 ---@type neotest.Config
 local default_config = {
-	log_level = vim.log.levels.WARN,
-	adapters = {},
-	discovery = {
-		enabled = true,
-		concurrent = 0,
-		filter_dir = nil,
-	},
-	running = {
-		concurrent = true,
-	},
-	consumers = {},
-	icons = {
-		-- Ascii:
-		-- { "/", "|", "\\", "-", "/", "|", "\\", "-"},
-		-- Unicode:
-		-- { "", "🞅", "🞈", "🞉", "", "", "🞉", "🞈", "🞅", "", },
-		-- {"◴" ,"◷" ,"◶", "◵"},
-		-- {"◢", "◣", "◤", "◥"},
-		-- {"◐", "◓", "◑", "◒"},
-		-- {"◰", "◳", "◲", "◱"},
-		-- {"⣾", "⣽", "⣻", "⢿", "⡿", "⣟", "⣯", "⣷"},
-		-- {"⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"},
-		-- {"⠋", "⠙", "⠚", "⠞", "⠖", "⠦", "⠴", "⠲", "⠳", "⠓"},
-		-- {"⠄", "⠆", "⠇", "⠋", "⠙", "⠸", "⠰", "⠠", "⠰", "⠸", "⠙", "⠋", "⠇", "⠆"},
-		-- { "⠋", "⠙", "⠚", "⠒", "⠂", "⠂", "⠒", "⠲", "⠴", "⠦", "⠖", "⠒", "⠐", "⠐", "⠒", "⠓", "⠋" },
-		running_animated = { "/", "|", "\\", "-", "/", "|", "\\", "-" },
-		passed = "",
-		running = "",
-		failed = "",
-		skipped = "",
-		unknown = "",
-		non_collapsible = "─",
-		collapsed = "─",
-		expanded = "╮",
-		child_prefix = "├",
-		final_child_prefix = "╰",
-		child_indent = "│",
-		final_child_indent = " ",
-	},
-	highlights = {
-		passed = "NeotestPassed",
-		running = "NeotestRunning",
-		failed = "NeotestFailed",
-		skipped = "NeotestSkipped",
-		test = "NeotestTest",
-		namespace = "NeotestNamespace",
-		focused = "NeotestFocused",
-		file = "NeotestFile",
-		dir = "NeotestDir",
-		border = "NeotestBorder",
-		indent = "NeotestIndent",
-		expand_marker = "NeotestExpandMarker",
-		adapter_name = "NeotestAdapterName",
-		select_win = "NeotestWinSelect",
-		marked = "NeotestMarked",
-		target = "NeotestTarget",
-		unknown = "NeotestUnknown",
-	},
-	floating = {
-		border = "rounded",
-		max_height = 0.6,
-		max_width = 0.6,
-		options = {},
-	},
-	default_strategy = "integrated",
-	strategies = {
-		integrated = {
-			width = 120,
-			height = 40,
-		},
-	},
-	summary = {
-		enabled = true,
-		animated = true,
-		follow = true,
-		expand_errors = true,
-		mappings = {
-			expand = { "<CR>", "<2-LeftMouse>" },
-			expand_all = "e",
-			output = "o",
-			short = "O",
-			attach = "a",
-			jumpto = "i",
-			stop = "u",
-			run = "r",
-			mark = "m",
-			run_marked = "R",
-			clear_marked = "M",
-			target = "t",
-			clear_target = "T",
-			next_failed = "J",
-			prev_failed = "K",
-		},
-	},
-	benchmark = {
-		enabled = true,
-	},
-	output = {
-		enabled = true,
-		open_on_run = "short",
-	},
-	diagnostic = {
-		enabled = true,
-	},
-	status = {
-		enabled = true,
-		virtual_text = false,
-		signs = true,
-	},
-	run = {
-		enabled = true,
-	},
-	jump = {
-		enabled = true,
-	},
-	state = {
-		enabled = true,
-	},
-	projects = {},
+  log_level = vim.log.levels.WARN,
+  adapters = {},
+  discovery = {
+    enabled = true,
+    concurrent = 0,
+    filter_dir = nil,
+  },
+  running = {
+    concurrent = true,
+  },
+  consumers = {},
+  icons = {
+    -- Ascii:
+    -- { "/", "|", "\\", "-", "/", "|", "\\", "-"},
+    -- Unicode:
+    -- { "", "🞅", "🞈", "🞉", "", "", "🞉", "🞈", "🞅", "", },
+    -- {"◴" ,"◷" ,"◶", "◵"},
+    -- {"◢", "◣", "◤", "◥"},
+    -- {"◐", "◓", "◑", "◒"},
+    -- {"◰", "◳", "◲", "◱"},
+    -- {"⣾", "⣽", "⣻", "⢿", "⡿", "⣟", "⣯", "⣷"},
+    -- {"⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"},
+    -- {"⠋", "⠙", "⠚", "⠞", "⠖", "⠦", "⠴", "⠲", "⠳", "⠓"},
+    -- {"⠄", "⠆", "⠇", "⠋", "⠙", "⠸", "⠰", "⠠", "⠰", "⠸", "⠙", "⠋", "⠇", "⠆"},
+    -- { "⠋", "⠙", "⠚", "⠒", "⠂", "⠂", "⠒", "⠲", "⠴", "⠦", "⠖", "⠒", "⠐", "⠐", "⠒", "⠓", "⠋" },
+    running_animated = { "/", "|", "\\", "-", "/", "|", "\\", "-" },
+    passed = "",
+    running = "",
+    failed = "",
+    skipped = "",
+    unknown = "",
+    non_collapsible = "─",
+    collapsed = "─",
+    expanded = "╮",
+    child_prefix = "├",
+    final_child_prefix = "╰",
+    child_indent = "│",
+    final_child_indent = " ",
+  },
+  highlights = {
+    passed = "NeotestPassed",
+    running = "NeotestRunning",
+    failed = "NeotestFailed",
+    skipped = "NeotestSkipped",
+    test = "NeotestTest",
+    namespace = "NeotestNamespace",
+    focused = "NeotestFocused",
+    file = "NeotestFile",
+    dir = "NeotestDir",
+    border = "NeotestBorder",
+    indent = "NeotestIndent",
+    expand_marker = "NeotestExpandMarker",
+    adapter_name = "NeotestAdapterName",
+    select_win = "NeotestWinSelect",
+    marked = "NeotestMarked",
+    target = "NeotestTarget",
+    unknown = "NeotestUnknown",
+  },
+  floating = {
+    border = "rounded",
+    max_height = 0.6,
+    max_width = 0.6,
+    options = {},
+  },
+  default_strategy = "integrated",
+  strategies = {
+    integrated = {
+      width = 120,
+      height = 40,
+    },
+  },
+  summary = {
+    enabled = true,
+    animated = true,
+    follow = true,
+    expand_errors = true,
+    mappings = {
+      expand = { "<CR>", "<2-LeftMouse>" },
+      expand_all = "e",
+      output = "o",
+      short = "O",
+      attach = "a",
+      jumpto = "i",
+      stop = "u",
+      run = "r",
+      mark = "m",
+      run_marked = "R",
+      clear_marked = "M",
+      target = "t",
+      clear_target = "T",
+      next_failed = "J",
+      prev_failed = "K",
+    },
+  },
+  benchmark = {
+    enabled = true,
+  },
+  output = {
+    enabled = true,
+    open_on_run = "short",
+  },
+  diagnostic = {
+    enabled = true,
+  },
+  status = {
+    enabled = true,
+    virtual_text = false,
+    signs = true,
+  },
+  run = {
+    enabled = true,
+  },
+  jump = {
+    enabled = true,
+  },
+  state = {
+    enabled = true,
+  },
+  projects = {},
 }
 
 local user_config = default_config
@@ -237,71 +237,71 @@ local user_config = default_config
 local NeotestConfigModule = {}
 
 local convert_concurrent = function(val)
-	if val == 0 or val == true then
-		return #vim.loop.cpu_info() + 4
-	end
-	if val == false then
-		return 1
-	end
-	assert(type(val) == "number", "concurrent must be a boolean or a number")
-	return val
+  if val == 0 or val == true then
+    return #vim.loop.cpu_info() + 4
+  end
+  if val == false then
+    return 1
+  end
+  assert(type(val) == "number", "concurrent must be a boolean or a number")
+  return val
 end
 
 ---@param config neotest.Config
 ---@private
 function NeotestConfigModule.setup(config)
-	---@type neotest.Config
-	user_config = vim.tbl_deep_extend("force", default_config, config)
-	--- Avoid mutating default for docgen
-	user_config.discovery = vim.tbl_deep_extend(
-		"force",
-		user_config.discovery,
-		{ concurrent = convert_concurrent(user_config.discovery.concurrent) }
-	)
+  ---@type neotest.Config
+  user_config = vim.tbl_deep_extend("force", default_config, config)
+  --- Avoid mutating default for docgen
+  user_config.discovery = vim.tbl_deep_extend(
+    "force",
+    user_config.discovery,
+    { concurrent = convert_concurrent(user_config.discovery.concurrent) }
+  )
 
-	user_config.projects = setmetatable({}, {
-		__index = function()
-			return user_config
-		end,
-	})
-	for project_root, project_config in pairs(config.projects or {}) do
-		NeotestConfigModule.setup_project(project_root, project_config)
-	end
+  user_config.projects = setmetatable({}, {
+    __index = function()
+      return user_config
+    end,
+  })
+  for project_root, project_config in pairs(config.projects or {}) do
+    NeotestConfigModule.setup_project(project_root, project_config)
+  end
 
-	local logger = require("neotest.logging")
-	logger:set_level(user_config.log_level)
-	logger.info("Configuration complete")
-	logger.debug("User config", user_config)
+  local logger = require("neotest.logging")
+  logger:set_level(user_config.log_level)
+  logger.info("Configuration complete")
+  logger.debug("User config", user_config)
 end
 
 function NeotestConfigModule.setup_project(project_root, config)
-	local path = vim.fn.fnamemodify(project_root, ":p")
-	path = path:sub(1, #path - 1) -- Trailing slash
-	user_config.projects[path] = vim.tbl_deep_extend("keep", config, {
-		adapters = user_config.adapters,
-		discovery = user_config.discovery,
-		running = user_config.running,
-	})
-	user_config.projects[path].discovery.concurrent =
-	convert_concurrent(user_config.projects[path].discovery.concurrent)
-	local logger = require("neotest.logging")
-	logger.info("Project", path, "configuration complete")
-	logger.debug("Project config", user_config.projects[path])
+  local path = vim.fn.fnamemodify(project_root, ":p")
+  path = path:sub(1, #path - 1) -- Trailing slash
+  user_config.projects[path] = vim.tbl_deep_extend("keep", config, {
+    adapters = user_config.adapters,
+    discovery = user_config.discovery,
+    running = user_config.running,
+  })
+  user_config.projects[path].discovery.concurrent =
+    convert_concurrent(user_config.projects[path].discovery.concurrent)
+  local logger = require("neotest.logging")
+  logger.info("Project", path, "configuration complete")
+  logger.debug("Project config", user_config.projects[path])
 end
 
 function NeotestConfigModule._format_default()
-	local lines = { "Default values:", ">" }
-	for line in vim.gsplit(vim.inspect(default_config), "\n", true) do
-		table.insert(lines, "  " .. line)
-	end
-	table.insert(lines, "<")
-	return lines
+  local lines = { "Default values:", ">" }
+  for line in vim.gsplit(vim.inspect(default_config), "\n", true) do
+    table.insert(lines, "  " .. line)
+  end
+  table.insert(lines, "<")
+  return lines
 end
 
 setmetatable(NeotestConfigModule, {
-	__index = function(_, key)
-		return user_config[key]
-	end,
+  __index = function(_, key)
+    return user_config[key]
+  end,
 })
 
 return NeotestConfigModule

--- a/lua/neotest/consumers/init.lua
+++ b/lua/neotest/consumers/init.lua
@@ -35,6 +35,7 @@ neotest.consumers = {
   summary = require("neotest.consumers.summary"),
   jump = require("neotest.consumers.jump"),
   benchmark = require("neotest.consumers.benchmark"),
+  state = require("neotest.consumers.state"),
 }
 
 return neotest.consumers

--- a/lua/neotest/consumers/state/init.lua
+++ b/lua/neotest/consumers/state/init.lua
@@ -1,0 +1,69 @@
+-- The state consumer acts as a cache for the internal test state as provided by
+-- by the neovim client. It can be used to query get the current number of
+-- passed/failed/skipped tests in a simple manner, to display in e.g. a statusbar.
+
+local internal_state = require("neotest.consumers.state.internal")
+
+local neotest = {}
+neotest.state = {}
+
+---Alias for client:get_adapters to get registerd adapters
+---@return string[]
+function neotest.state.get_adapters()
+  return internal_state:get_adapters()
+end
+
+---Get back results from cache
+---@param path_query string
+---@param opts table
+---       :fuzzy use string.match instead of direct comparison for key
+---@return table | nil
+function neotest.state.get_status(path_query, opts)
+  return internal_state:get_status(path_query, opts)
+end
+
+---Get status count (passed | failed | skipped | unknown)
+---@param path_query string
+---@param opts table
+---       :fuzzy use string.match instead of direct comparison for key
+---       :status get count for status
+---@return integer returns status count, -1 if no status is provided
+function neotest.state.get_status_count(path_query, opts)
+  return internal_state:get_status_count(path_query, opts)
+end
+
+---Return entire status cache from the last run.
+---ONLY returns the results from the last run per file, not the enire test history.
+---@return table<string, table>
+function neotest.state.get_status_all()
+  return internal_state:get_status_all()
+end
+
+---Gives back unparsed results
+---Get back results from cache
+function neotest.state.get_raw_results()
+  return internal_state:get_raw_results()
+end
+
+---Check if there are tests running
+---Optionally, provide a "<adapter_id>:<file_path>" argument to filter on.
+---If no argument is provided, all running processes will be returned.
+---If nil is returned your adapter_id found no match, otherwise an emtpy
+---table is returned.
+---@param adapter_id string optional
+---@param opts table
+---       :fuzzy use string.match instead of direct comparison for key
+---       :as_array if no addapter_id provided, return entire list as array
+---@return table<string, string> | string[] | nil
+function neotest.state.running(adapter_id, opts)
+  return internal_state:running(adapter_id, opts)
+end
+
+neotest.state = setmetatable(neotest.state, {
+  __call = function(_, _client)
+    internal_state:init(_client)
+    return neotest.state
+  end,
+})
+
+return neotest.state

--- a/lua/neotest/consumers/state/init.lua
+++ b/lua/neotest/consumers/state/init.lua
@@ -19,6 +19,9 @@ end
 ---@field status string optionally fetch count for specific status (passed | failed | skipped | unknown)
 ---@field query string optionally get result back for specific file or path
 ---@field fuzzy string use string.match instead of direct comparison for key
+---@field total boolean return total results. If used in combination with a query
+---       the query result will take precent if present, otherwise total will be used as fallback.
+---       This is useful when you want to return package wide results on non-code windows
 ---@return table | nil
 function neotest.state.get_status(opts)
   return internal_state:get_status(opts)

--- a/lua/neotest/consumers/state/init.lua
+++ b/lua/neotest/consumers/state/init.lua
@@ -13,23 +13,15 @@ function neotest.state.get_adapters()
   return internal_state:get_adapters()
 end
 
----Get back results from cache. Fetches all results by default.
+---Get back status results from cache. Fetches all results by default.
+---Can be used to fetch the count for a specific status.
 ---@param opts table
----@field path_query string optionally get result back for specific file or path
+---@field status string optionally fetch count for specific status (passed | failed | skipped | unknown)
+---@field query string optionally get result back for specific file or path
 ---@field fuzzy string use string.match instead of direct comparison for key
 ---@return table | nil
 function neotest.state.get_status(opts)
   return internal_state:get_status(opts)
-end
-
----Get status count (passed | failed | skipped | unknown)
----@param path_query string
----@param opts table
----       :fuzzy use string.match instead of direct comparison for key
----       :status get count for status
----@return integer returns status count, -1 if no status is provided
-function neotest.state.get_status_count(path_query, opts)
-  return internal_state:get_status_count(path_query, opts)
 end
 
 ---Gives back unparsed results

--- a/lua/neotest/consumers/state/init.lua
+++ b/lua/neotest/consumers/state/init.lua
@@ -32,8 +32,7 @@ function neotest.state.get_status_count(path_query, opts)
   return internal_state:get_status_count(path_query, opts)
 end
 
----Return entire status cache from the last run.
----ONLY returns the results from the last run per file, not the enire test history.
+---Return entire status cache for all paths
 ---@return table<string, table>
 function neotest.state.get_status_all()
   return internal_state:get_status_all()

--- a/lua/neotest/consumers/state/init.lua
+++ b/lua/neotest/consumers/state/init.lua
@@ -33,12 +33,11 @@ function neotest.state.get_raw_results()
   return internal_state:get_raw_results()
 end
 
----Check if there are tests running
+---Check if there are tests currently running
 ---If no options are provided, all running processes will be returned.
----If nil is returned your adapter_id found no match, otherwise an empty
----table is returned.
+---If either no tests are running, or the query found no match, nil is returned
 ---@param opts table
----@field adapter_id string Optionally, provide a "<adapter_id>:<file_path>" argument to filter on.
+---@field query string Optionally, provide a query to filter on.
 ---@field fuzzy string use string.match instead of direct comparison for key
 ---@return table<string, string> | string[] | nil
 function neotest.state.running(opts)

--- a/lua/neotest/consumers/state/init.lua
+++ b/lua/neotest/consumers/state/init.lua
@@ -1,5 +1,5 @@
 -- The state consumer acts as a cache for the internal test state as provided by
--- by the neovim client. It can be used to query get the current number of
+-- by the neotest core. It can be used to query get the current number of
 -- passed/failed/skipped tests in a simple manner, to display in e.g. a statusbar.
 
 local internal_state = require("neotest.consumers.state.internal")
@@ -7,19 +7,19 @@ local internal_state = require("neotest.consumers.state.internal")
 local neotest = {}
 neotest.state = {}
 
----Alias for client:get_adapters to get registerd adapters
+---Get the list of all known adapter IDs
 ---@return string[]
 function neotest.state.get_adapters()
   return internal_state:get_adapters()
 end
 
----Get back results from cache
----@param path_query string
+---Get back results from cache. Fetches all results by default.
 ---@param opts table
----       :fuzzy use string.match instead of direct comparison for key
+---@field path_query string optionally get result back for specific file or path
+---@field fuzzy string use string.match instead of direct comparison for key
 ---@return table | nil
-function neotest.state.get_status(path_query, opts)
-  return internal_state:get_status(path_query, opts)
+function neotest.state.get_status(opts)
+  return internal_state:get_status(opts)
 end
 
 ---Get status count (passed | failed | skipped | unknown)
@@ -32,12 +32,6 @@ function neotest.state.get_status_count(path_query, opts)
   return internal_state:get_status_count(path_query, opts)
 end
 
----Return entire status cache for all paths
----@return table<string, table>
-function neotest.state.get_status_all()
-  return internal_state:get_status_all()
-end
-
 ---Gives back unparsed results
 ---Get back results from cache
 function neotest.state.get_raw_results()
@@ -45,17 +39,15 @@ function neotest.state.get_raw_results()
 end
 
 ---Check if there are tests running
----Optionally, provide a "<adapter_id>:<file_path>" argument to filter on.
----If no argument is provided, all running processes will be returned.
----If nil is returned your adapter_id found no match, otherwise an emtpy
+---If no options are provided, all running processes will be returned.
+---If nil is returned your adapter_id found no match, otherwise an empty
 ---table is returned.
----@param adapter_id string optional
 ---@param opts table
----       :fuzzy use string.match instead of direct comparison for key
----       :as_array if no addapter_id provided, return entire list as array
+---@field adapter_id string Optionally, provide a "<adapter_id>:<file_path>" argument to filter on.
+---@field fuzzy string use string.match instead of direct comparison for key
 ---@return table<string, string> | string[] | nil
-function neotest.state.running(adapter_id, opts)
-  return internal_state:running(adapter_id, opts)
+function neotest.state.running(opts)
+  return internal_state:running(opts)
 end
 
 neotest.state = setmetatable(neotest.state, {

--- a/lua/neotest/consumers/state/internal.lua
+++ b/lua/neotest/consumers/state/internal.lua
@@ -141,34 +141,35 @@ end
 
 ---Get back results from cache. Fetches all results by default.
 ---@param opts table
----@field path_query string optionally get result back for specific file or path
+---@field status string fetch count for specific status (passed | failed | skipped | unknown)
+---@field query string optionally get result back for specific file or path
 ---@field fuzzy string use string.match instead of direct comparison for key
 ---@return table | nil
 function state:get_status(opts)
   opts = opts or {}
-  if not opts.path_query then
+  local status = self:_get_status(opts)
+  if opts.status then
+    return status and status[opts.status]
+  end
+  return status
+end
+
+---Get back results from cache
+---@param opts table
+---@field query string optionally get result back for specific file or path
+---@field fuzzy string use string.match instead of direct comparison for key
+---@return table | nil
+function state:_get_status(opts)
+  opts = opts or {}
+  if not opts.query then
     return self._cache
   end
   for key, val in pairs(self._cache) do
-    if key == opts.path_query or (opts.fuzzy and fuzzy_match(key, opts.path_query)) then
+    if key == opts.query or (opts.fuzzy and fuzzy_match(key, opts.query)) then
       return val
     end
   end
   return nil
-end
-
----Get status count (passed | failed | skipped | unknown)
----@param path_query string
----@param opts table
----       :fuzzy use string.match instead of direct comparison for key
----       :status get count for status
----@return integer returns status count, -1 if no status is provided
-function state:get_status_count(path_query, opts)
-  if not opts and not opts.status then
-    return -1
-  end
-  local status = self:get_status(path_query, opts)
-  return status and status[opts.status] or 0
 end
 
 ---Gives back unparsed results

--- a/lua/neotest/consumers/state/internal.lua
+++ b/lua/neotest/consumers/state/internal.lua
@@ -168,7 +168,7 @@ function state:get_status_count(path_query, opts)
   return status and status[opts.status] or 0
 end
 
----Return entire status cache
+---Return entire status cache for all paths
 ---@return table<string, table>
 function state:get_status_all()
   return self._cache

--- a/lua/neotest/consumers/state/internal.lua
+++ b/lua/neotest/consumers/state/internal.lua
@@ -1,0 +1,198 @@
+local au_result = "NeoTestStatus"
+local au_running = "NeoTestStarted"
+
+---@class state
+---@field private _result table<integer, table<string, neotest.Tree> >
+---@field private _status table
+---@field private _cache table
+---@field private _running table<string, table<string, string>>
+---@field private _adapters table<integer, string>
+---@field private _client neotest.Client
+state = {
+  _result = {},
+  _status = {},
+  _cache = {},
+  _running = {},
+  _adapters = {},
+}
+
+---Escape characters that have a special meaning in patterns
+---@param text string
+---@return string
+local function escape(text)
+  text = text:gsub("%-", "%%-")
+  text = text:gsub("%.", "%%.")
+  return text
+end
+
+---Update the internal list of currently running tests
+---@param adapter_id string
+---@param position_ids string
+function state:_update_running(adapter_id, position_ids)
+  self._running[position_ids] = {
+    adapter = string.match(adapter_id, "(.-):"),
+    path = position_ids,
+  }
+
+  -- Trigger Event
+  vim.api.nvim_exec_autocmds(
+    "User",
+    { pattern = au_running, data = { id = adapter_id, running = position_ids } }
+  )
+end
+
+---Process results and count pass/fail rates, save to cache
+-- Passed, Failed, Skipped
+---@param results table<string, neotest.Result>
+function state:_process_result(results)
+  for path, data in pairs(results) do
+    local test_path = string.match(path, "^([^:]*)::")
+    if test_path ~= nil then
+      local test_name = string.match(path, escape(test_path) .. "::(.*)")
+      self:_set_status(test_path, test_name, data.status)
+    end
+  end
+  self:_update_cache()
+end
+
+---Update status for specific test
+---@param path string
+---@param status string
+function state:_set_status(path, name, status)
+  if self._status[path] == nil then
+    self._status[path] = {}
+  end
+  self._status[path][name] = status
+end
+
+---Update the cache status count
+function state:_update_cache()
+  for path, results in pairs(self._status) do
+    local count = { passed = 0, failed = 0, skipped = 0, unknown = 0 }
+    for _, status in pairs(results) do
+      count[status] = count[status] + 1
+    end
+    self._cache[path] = count
+  end
+end
+
+---Receive result from event and add to internal state
+---@param adapter_id string
+---@param results table<string, neotest.Result>
+function state:_update_results(adapter_id, results)
+  self._running[string.match(adapter_id, "^[^:]*:(.*)")] = nil
+  self._result[adapter_id] = results
+
+  self:_process_result(results)
+
+  -- Trigger Event
+  vim.api.nvim_exec_autocmds(
+    "User",
+    { pattern = au_result, data = { id = adapter_id, result = results } }
+  )
+end
+
+---Alias for client:get_adapters to get registerd adapters
+---@return string[]
+function state:get_adapters()
+  return self._client:get_adapters()
+end
+
+---Check if there are tests running
+---Optionally, provide a "<adapter_id>:<file_path>" argument to filter on.
+---If no argument is provided, all running processes will be returned.
+---If nil is returned your adapter_id found no match, otherwise an emtpy
+---table is returned.
+---@param adapter_id string optional
+---@param opts table
+---       :fuzzy use string.match instead of direct comparison for key
+---       :as_array if no addapter_id provided, return entire list as array
+---@return table<string, string> | string[] | nil
+function state:running(adapter_id, opts)
+  if adapter_id == nil or (type(adapter_id) ~= string and #adapter_id == 0) then
+    if opts and not opts.as_array then
+      return next(self._running) and self._running or nil
+    end
+
+    local array = {}
+    local i = 1
+    for _, v in pairs(self._running) do
+      array[i] = v
+      i = i + 1
+    end
+    return array
+  end
+
+  for key, value in pairs(self._running) do
+    if
+      (
+        key == adapter_id
+        or (
+          opts
+          and opts.fuzzy
+          and (string.match(adapter_id, escape(key)) or string.match(key, escape(adapter_id)))
+        )
+      ) and next(value) ~= nil
+    then
+      return value
+    end
+  end
+  return nil
+end
+
+---Get back results from cache
+---@param path_query string
+---@param opts table
+---       :fuzzy use string.match instead of direct comparison for key
+---@return table | nil
+function state:get_status(path_query, opts)
+  for key, val in pairs(self._cache) do
+    if key == path_query or (opts and opts.fuzzy and string.match(key, path_query)) then
+      return val
+    end
+  end
+  return nil
+end
+
+---Get status count (passed | failed | skipped | unknown)
+---@param path_query string
+---@param opts table
+---       :fuzzy use string.match instead of direct comparison for key
+---       :status get count for status
+---@return integer returns status count, -1 if no status is provided
+function state:get_status_count(path_query, opts)
+  if not opts and not opts.status then
+    return -1
+  end
+  local status = self:get_status(path_query, opts)
+  return status and status[opts.status] or 0
+end
+
+---Return entire status cache
+---@return table<string, table>
+function state:get_status_all()
+  return self._cache
+end
+
+---Gives back unparsed results
+---Get back results from cache
+function state:get_raw_results()
+  return self._result
+end
+
+---@param client neotest.Client
+function state:init(client)
+  self._client = client
+
+  -- Register event listerer to receive state
+  -- This gets run twice for one event ??
+  client.listeners.results = function(adapter_id, results)
+    self:_update_results(adapter_id, results)
+  end
+
+  client.listeners.run = function(adapter_id, position_ids)
+    self:_update_running(adapter_id, position_ids)
+  end
+end
+
+return state


### PR DESCRIPTION
Added a consumer that serves as an internal state cache, which can be consumed for use in e.g. status bars

My status bar example:
![image](https://user-images.githubusercontent.com/25869544/198726329-466ed1fc-2d25-4b4a-af53-808ce9d23531.png)

Ref: #110 