### PR TITLE
feat(summary): add summary_toggle event

### DIFF
--- a/lua/neotest/client/events/init.lua
+++ b/lua/neotest/client/events/init.lua
@@ -6,11 +6,15 @@ local M = {}
 ---@alias neotest.Event "discover_positions" | "run" | "results" | "test_file_focused" | "test_focused"
 ---@class neotest.Events
 local NeotestEvents = {
+  -- Core
   DISCOVER_POSITIONS = "discover_positions",
   RUN = "run",
   RESULTS = "results",
   TEST_FILE_FOCUSED = "test_file_focused",
   TEST_FOCUSED = "test_focused",
+
+  -- Summary
+  SUMMARY_TOGGLE = "summary_toggle",
 }
 
 M.events = NeotestEvents

--- a/lua/neotest/consumers/summary/init.lua
+++ b/lua/neotest/consumers/summary/init.lua
@@ -33,6 +33,7 @@ local function open_window(buf)
   async.api.nvim_win_set_buf(win, buf)
   async.api.nvim_set_current_win(cur_win)
   async.api.nvim_buf_set_option(summary_buf, "filetype", "neotest-summary")
+  client._events:emit("summary_toggle", true)
 end
 
 local components = {}
@@ -183,6 +184,7 @@ local function close()
   if is_open() then
     local win = async.fn.win_getid(async.fn.bufwinnr(summary_buf))
     async.api.nvim_win_close(win, true)
+    client._events:emit("summary_toggle", false)
   end
 end
 


### PR DESCRIPTION
This is emitted when the summary window is opened (`true`) or closed (`false`), allowing other consumers to perform actions when the summary window is toggled.

In my case, I want to enable automatic running of tests on write only when the summary window is open: I will likely tie other behaviour in my configuration to this state too, as a proxy for "concentrating on tests".

(I investigated adding events to consumers (so that the event could be defined within `summary/init.lua` itself), but it was getting complicated: it would require extending the Client interface, and most consumers won't need it. If you'd prefer a more general solution, I'm happy to hack at it some more!)