### PR TITLE
Add return annotation for `filter_dir` interface

### DIFF
--- a/lua/neotest/adapters/interface.lua
+++ b/lua/neotest/adapters/interface.lua
@@ -14,6 +14,7 @@ function NeotestAdapter.root(dir) end
 ---@param name string Name of directory
 ---@param rel_path string Path to directory, relative to root
 ---@param root string Root directory of project
+---@return boolean
 function NeotestAdapter.filter_dir(name, rel_path, root) end
 
 ---@async


### PR DESCRIPTION
Thought this might help future devs more easily discover the joy of the `filter_dir` interface you showed me in #154. :)