### PR TITLE
feat: started and starting events

### DIFF
--- a/lua/neotest/client/events/init.lua
+++ b/lua/neotest/client/events/init.lua
@@ -3,7 +3,7 @@ local logger = require("neotest.logging")
 
 local M = {}
 
----@alias neotest.Event "discover_positions" | "run" | "results" | "test_file_focused" | "test_focused"
+---@alias neotest.Event "discover_positions" | "run" | "results" | "test_file_focused" | "test_focused" | "starting" | "started"
 ---@class neotest.Events
 local NeotestEvents = {
   DISCOVER_POSITIONS = "discover_positions",
@@ -11,6 +11,8 @@ local NeotestEvents = {
   RESULTS = "results",
   TEST_FILE_FOCUSED = "test_file_focused",
   TEST_FOCUSED = "test_focused",
+  STARTING = "starting",
+  STARTED = "started",
 }
 
 M.events = NeotestEvents

--- a/lua/neotest/consumers/run.lua
+++ b/lua/neotest/consumers/run.lua
@@ -5,6 +5,7 @@ local lib = require("neotest.lib")
 ---@type neotest.Client
 local client
 local last_run
+local client_ready = false
 
 local neotest = {}
 
@@ -190,7 +191,7 @@ end
 
 --- Get the list of all known adapter IDs.
 function neotest.run.adapters()
-  if not client:has_started() then
+  if not client_ready then
     return {}
   end
   return client:get_adapters()
@@ -206,8 +207,12 @@ function neotest.run.get_last_run()
 end
 
 neotest.run = setmetatable(neotest.run, {
+  ---@param client_ neotest.Client
   __call = function(_, client_)
     client = client_
+    client.listeners.starting = function()
+      client_ready = true
+    end
     return neotest.run
   end,
 })

--- a/lua/neotest/consumers/summary/init.lua
+++ b/lua/neotest/consumers/summary/init.lua
@@ -5,6 +5,7 @@ local config = require("neotest.config")
 
 ---@type neotest.Summary
 local summary
+---@param client neotest.Client
 local function init(client)
   summary = Summary(client)
 
@@ -31,6 +32,14 @@ local function init(client)
       end
     end
     summary:render(expanded)
+  end
+
+  client.listeners.starting = function()
+    summary:set_starting()
+  end
+
+  client.listeners.started = function()
+    summary:set_started()
   end
 
   if config.summary.follow then

--- a/lua/neotest/types/init.lua
+++ b/lua/neotest/types/init.lua
@@ -48,6 +48,8 @@
 ---@field results fun(adapter_id: string, results: table<string, neotest.Result>, partial: boolean)
 ---@field test_file_focused fun(adapter_id: string, file_path: string)>
 ---@field test_focused fun(adapter_id: string, position_id: string)>
+---@field starting fun()
+---@field started fun()
 
 ---@class neotest.Client : neotest.InternalClient
 ---@field listeners neotest.ConsumerListeners

--- a/tests/unit/client/init_spec.lua
+++ b/tests/unit/client/init_spec.lua
@@ -164,7 +164,7 @@ describe("neotest client", function()
       end)
       a.it("it reads the files", function()
         files[#files + 1] = dir .. "/test_file_3"
-        client:ensure_started()
+        client:_ensure_started()
         client:_update_positions(dir .. "/test_file_3")
         local file_tree = get_pos(dir .. "/test_file_3")
         assert.Not.same(file_tree:children(), {})
@@ -174,7 +174,7 @@ describe("neotest client", function()
     describe("when looking for new directory", function()
       a.it("it reads the new directory", function()
         dirs = { dir, dir .. "/new_dir" }
-        client:ensure_started()
+        client:_ensure_started()
         files[#files + 1] = dir .. "/new_dir/test_file_3"
         client:_update_positions(dir .. "/new_dir")
         local file_tree = get_pos(dir .. "/new_dir")
@@ -320,7 +320,7 @@ describe("neotest client", function()
 
           dirs = { dir, dir .. "/new_dir" }
           files[#files + 1] = dir .. "/new_dir/test_file_3"
-          client:ensure_started()
+          client:_ensure_started()
           local child_file = client:get_position(dir .. "/new_dir/test_file_3")
 
           mock_adapter.build_spec = function(args)


### PR DESCRIPTION
BREAKING CHANGE: Removes the `has_started` and `ensure_started` client methods

See #157