### PR TITLE
fix: run fails if there are unloaded buffers

### DIFF
--- a/lua/neotest/adapters/init.lua
+++ b/lua/neotest/adapters/init.lua
@@ -34,8 +34,11 @@ function AdapterGroup:adapters_matching_open_bufs(existing_roots)
   local buffers = async.api.nvim_list_bufs()
 
   local paths = lib.func_util.map(function(i, buf)
-    local path = async.api.nvim_buf_get_name(buf)
-    local real = lib.files.path.real(path)
+    local real
+    if async.api.nvim_buf_is_loaded(buf) then
+      local path = async.api.nvim_buf_get_name(buf)
+      real = lib.files.path.real(path)
+    end
     return i, real or false
   end, buffers)
 


### PR DESCRIPTION
`vim.api.nvim_buf_get_name()` will throw an error if run on an unloaded buffer. I'm using `noice.nvim` which I think creates some unloaded buffers.

This PR adds a check to ensure the buffer is loaded before trying to get the name.