### PR TITLE
fix: don't error if adapter has no root position

### DIFF
--- a/lua/neotest/client/init.lua
+++ b/lua/neotest/client/init.lua
@@ -396,7 +396,10 @@ function neotest.Client:_start(args)
       local adapter_id = self:_get_adapter(file_path)
       if not adapter_id then
         for a_id, _ in pairs(self._adapters) do
-          local root = assert(self:get_position(nil, { adapter = a_id }))
+          local root = self:get_position(nil, { adapter = a_id })
+          if not root then
+            return
+          end
           if vim.startswith(file_path, root:data().path) then
             logger.info(
               "Not updating positions for",


### PR DESCRIPTION
I'm seeing an error when setting `discovery.enabled = false`. I have an adapter that does not have any valid tests discovered, and thus has no root position in the state. This causes the assert here to always fail, which means that I see an error on every `BufAdd` and `BufWritePost`. The repro is as follows:

1. Open a file in a different language from the test adapter
2. Open the summary pane `require("neotest").summary.toggle()`
3. Open any new buffer `:enew`
Observe error

The fix I put in was to silently ignore the adapter if there is no root. I think this is fine (as that is a valid state), but let me know if that is not the case.