### PR TITLE
fix: check for not available test before trying getting results

### DIFF
--- a/lua/neotest/client/runner.lua
+++ b/lua/neotest/client/runner.lua
@@ -264,8 +264,11 @@ function TestRunner:_missing_results(tree, results, partial)
 
   if partial then
     for _, test_id in ipairs(missing_tests) do
-      for parent in tree:get_key(test_id):iter_parents() do
-        results_proxy[parent:data().id] = nil
+      local test = tree:get_key(test_id)
+      if test then
+        for parent in test:iter_parents() do
+          results_proxy[parent:data().id] = nil
+        end
       end
     end
   else


### PR DESCRIPTION
This will solve error:
```
Error executing luv callback:                                                                                   
...ck/packer/start/plenary.nvim/lua/plenary/async/async.lua:18: The coroutine failed with this message: ...ck/pa
cker/start/plenary.nvim/lua/plenary/async/async.lua:18: The coroutine failed with this message: ...ck/packer/sta
rt/plenary.nvim/lua/plenary/async/async.lua:18: The coroutine failed with this message: ...ck/packer/start/plena
ry.nvim/lua/plenary/async/async.lua:18: The coroutine failed with this message: .../pack/packer/start/neotest/lu
a/neotest/client/runner.lua:267: attempt to index a nil value                                                   
stack traceback:      
```