### PR TITLE
quickfix: always set QF list after a test run

### DIFF
--- a/lua/neotest/consumers/quickfix.lua
+++ b/lua/neotest/consumers/quickfix.lua
@@ -57,8 +57,8 @@ local init = function()
       return a.filename < b.filename
     end)
 
+    async.fn.setqflist(qf_results)
     if #qf_results > 0 then
-      async.fn.setqflist(qf_results)
       if config.quickfix.open then
         if type(config.quickfix.open) == "function" then
           config.quickfix.open()


### PR DESCRIPTION
otherwise we wouldn't remove obsolete errors after fixing a test.