### PR TITLE
fix: set window filetype earlier

### DIFF
--- a/lua/neotest/lib/window.lua
+++ b/lua/neotest/lib/window.lua
@@ -33,6 +33,13 @@ function PersistentWindow:open()
     return self._win
   end
 
+  if not self._has_opened then
+    if self._bufopts.filetype then
+      async.api.nvim_buf_set_option(self:buffer(), "filetype", self._bufopts.filetype)
+    end
+    self._has_opened = true
+  end
+
   local cur_win = async.api.nvim_get_current_win()
 
   if type(self._open) == "string" then
@@ -48,13 +55,6 @@ function PersistentWindow:open()
 
   for k, v in pairs(self._winopts) do
     async.api.nvim_win_set_option(self._win, k, v)
-  end
-
-  if not self._has_opened then
-    if self._bufopts.filetype then
-      async.api.nvim_buf_set_option(self:buffer(), "filetype", self._bufopts.filetype)
-    end
-    self._has_opened = true
   end
 
   return self._win


### PR DESCRIPTION
I had an issue where neotest clashes with the window-resizing plugin [windows.nvim](https://github.com/anuvyklack/windows.nvim/) when opening the the test summary window, despite explicitly telling window.nvim to ignore the `neotest-summary` filetype.

It turns out that neotest sets the filetype `neotest-summary` too late. windows.nvim triggers on `BufWinEnter` and checks the filetype, which wasn't yet set by neotest. I can imagine that more plugins that check the filetype on `BufWinEnter` (or similar events) would have the same issue.

In this PR the window filetype is set as early as possible on open, which fixes the issue. I'm not sure if my solution is the best way to solve it, so feel free to tweak it!