### PR TITLE
fix(deprecation): Use query.parse to avoid deprecation warning

### DIFF
--- a/lua/neotest/lib/treesitter/init.lua
+++ b/lua/neotest/lib/treesitter/init.lua
@@ -100,7 +100,8 @@ end
 ---@return table
 function neotest.lib.treesitter.normalise_query(lang, query)
   if type(query) == "string" then
-    query = vim.treesitter.parse_query(lang, query)
+    local parse_query = vim.treesitter.query.parse or vim.treesitter.parse_query
+    query = parse_query(lang, query)
   end
   return query
 end


### PR DESCRIPTION
See https://github.com/neovim/neovim/pull/22761

Couldn't run the tests. Getting an error about plenary:
```
E492: Not an editor command: PlenaryBustedDirectory tests/ {minimal_init = 'tests/init.vim'}
```