### PR TITLE
Enhance diagnotic column position

### DIFF
--- a/lua/neotest/consumers/diagnostic.lua
+++ b/lua/neotest/consumers/diagnostic.lua
@@ -72,18 +72,6 @@ local function init(client)
   end
 
   function BufferDiagnostics:create_diagnostics(positions, results)
-    local function count_leading_spaces(str, count)
-      count = count or 0
-      local first_char = str:sub(1, 1)
-
-      if first_char == " " or first_char == "\t" then
-        local remaining_string = str:sub(2)
-        return count_leading_spaces(remaining_string, count + 1)
-      else
-        return count
-      end
-    end
-
     local bufnr = self.bufnr
     local diagnostics = {}
     for _, position in positions:iter() do
@@ -109,7 +97,7 @@ local function init(client)
             if mark_code == self.error_code_lines[pos_id][error_i] then
               diagnostics[#diagnostics + 1] = {
                 lnum = mark[1],
-                col = count_leading_spaces(mark_code),
+                col = mark_code:find("%S") - 1,
                 message = error.message,
                 source = "neotest",
                 severity = config.diagnostic.severity,

--- a/lua/neotest/consumers/diagnostic.lua
+++ b/lua/neotest/consumers/diagnostic.lua
@@ -72,6 +72,18 @@ local function init(client)
   end
 
   function BufferDiagnostics:create_diagnostics(positions, results)
+    local function count_leading_spaces(str, count)
+      count = count or 0
+      local first_char = str:sub(1, 1)
+
+      if first_char == " " or first_char == "\t" then
+        local remaining_string = str:sub(2)
+        return count_leading_spaces(remaining_string, count + 1)
+      else
+        return count
+      end
+    end
+
     local bufnr = self.bufnr
     local diagnostics = {}
     for _, position in positions:iter() do
@@ -93,10 +105,11 @@ local function init(client)
               {}
             )
             local mark_code = api.nvim_buf_get_lines(bufnr, mark[1], mark[1] + 1, false)[1]
+
             if mark_code == self.error_code_lines[pos_id][error_i] then
               diagnostics[#diagnostics + 1] = {
                 lnum = mark[1],
-                col = 0,
+                col = count_leading_spaces(mark_code),
                 message = error.message,
                 source = "neotest",
                 severity = config.diagnostic.severity,


### PR DESCRIPTION
If the column is 0, but the code doesn't start on the first column, which isn't what we want. The cursor will be placed to the left of the actual definition.


### before

<img width="474" alt="image" src="https://user-images.githubusercontent.com/12830256/230540582-67e69118-4314-408b-ba82-06cebfb736b6.png">


### After this pr

<img width="409" alt="image" src="https://user-images.githubusercontent.com/12830256/230540827-ce98d6ce-691d-4959-b0b9-0c72b3408ce1.png">
