### PR TITLE
fix(client): dap handler cleanup bug

### DIFF
--- a/lua/neotest/client/strategies/dap/init.lua
+++ b/lua/neotest/client/strategies/dap/init.lua
@@ -53,6 +53,7 @@ return function(spec)
     end,
     after = function()
       dap.listeners.after.event_output[handler_id] = nil
+      dap.listeners.after.event_exited[handler_id] = nil
       if adapter_after then
         adapter_after()
       end


### PR DESCRIPTION
Fixed a bug where a zombie handler was raising error when consequently running debug test in the same neovim session.

### Reproduce

- Go to a test
- Run `neotest.run.run({strategy='dap'})` two times in the same neovim session

### Bug

```sh
Error executing vim.schedule lua callback: .../neotest/lua/nio/control.lua:88: Future already set
stack traceback:
        [C]: in function 'error'
        .../neotest/lua/nio/control.lua:88: in function 'set'
        .../neotest/client/strategies/dap/init.lua:49: in function 'c'
        .../nvim-dap/lua/dap/session.lua:982: in function <.../nvim-dap/lua/dap/session.lua:970>
```

### Cause
Because the `event_exited` event handler was not cleaned up, it was called twice unintentionally in the next run. Cleaning up the event handler was missing after dap execution.