### PR TITLE
fix: utilize bufhidden=wipe instead of forcibly deleting buffer

### DIFF
--- a/lua/neotest/client/strategies/integrated/init.lua
+++ b/lua/neotest/client/strategies/integrated/init.lua
@@ -91,6 +91,7 @@ return function(spec)
         buffer = attach_buf,
       })
       vim.api.nvim_buf_set_option(attach_buf, "filetype", "neotest-attach")
+      vim.api.nvim_buf_set_option(attach_buf, "bufhidden", "wipe")
       attach_win:jump_to()
     end,
     result = function()

--- a/lua/neotest/consumers/output.lua
+++ b/lua/neotest/consumers/output.lua
@@ -51,7 +51,6 @@ local function open_output(result, opts)
   end
 
   local on_close = function()
-    pcall(vim.api.nvim_buf_delete, buf, { force = true })
     pcall(vim.fn.chanclose, chan)
     win = nil
   end


### PR DESCRIPTION
This fixes issues with autocmds such as `WinLeave` not firing,
presumable due to the fact that the floating window gets disposed of
when its buffer is deleted. This breaks plugins such as
[tint.nvim][tint.nvim] who rely on `WinLeave` to function properly.

[tint.nvim]: https://github.com/levouh/tint.nvim/issues/38
