### PR TITLE
Check for buffer existence on attach function

### DIFF
--- a/lua/neotest/client/strategies/integrated/init.lua
+++ b/lua/neotest/client/strategies/integrated/init.lua
@@ -74,7 +74,11 @@ return function(spec)
       end
     end,
     attach = function()
-      if not attach_buf then
+      -- nvim_create_buf returns 0 on error, but bufexists(0) tests for
+      -- existance of an alternate file name, so coerce 0 to nil
+      if attach_buf == 0 then attach_buf = nil end
+
+      if vim.fn.bufexists(attach_buf) == 0 then
         attach_buf = nio.api.nvim_create_buf(false, true)
         attach_chan = lib.ui.open_term(attach_buf, {
           on_input = function(_, _, _, data)


### PR DESCRIPTION
I've ran into a bug that prevents users to attach to a running test more than once. To replicate, run a long running test, attach to it, close the floating window, and try to attach to the test again. 

You should currently get an error message like so:
<details>
E5108: Error executing lua ...e/janmo/.local/share/nvim/lazy/neotest/lua/nio/tasks.lua:95: Async task failed without callback: The coroutine failed with this message: 
...cal/share/nvim/lazy/neotest/lua/neotest/lib/ui/float.lua:104: Invalid buffer id: 3
stack traceback:
	[C]: in function 'nvim_open_win'
	...cal/share/nvim/lazy/neotest/lua/neotest/lib/ui/float.lua:104: in function 'open'
	...eotest/lua/neotest/client/strategies/integrated/init.lua:88: in function 'attach'
	...nvim/lazy/neotest/lua/neotest/client/strategies/init.lua:85: in function 'attach'
	...al/share/nvim/lazy/neotest/lua/neotest/client/runner.lua:214: in function 'attach'
	...ocal/share/nvim/lazy/neotest/lua/neotest/client/init.lua:140: in function 'attach'
	...al/share/nvim/lazy/neotest/lua/neotest/consumers/run.lua:168: in function 'func'
	...e/janmo/.local/share/nvim/lazy/neotest/lua/nio/tasks.lua:166: in function <...e/janmo/.local/share/nvim/lazy/neotest/lua/nio/tasks.lua:165>
stack traceback:
	[C]: in function 'error'
	...e/janmo/.local/share/nvim/lazy/neotest/lua/nio/tasks.lua:95: in function 'close_task'
	...e/janmo/.local/share/nvim/lazy/neotest/lua/nio/tasks.lua:117: in function 'step'
	...e/janmo/.local/share/nvim/lazy/neotest/lua/nio/tasks.lua:143: in function 'attach'
	[string ":lua"]:1: in main chunk
</details>

When a buffer is created for the attached window, its ID is kept around to be reused in case we want to attach it again. However, the attached buffer gets wiped when a floating window gets closed, so the buffer no longer exists when attaching a second time, causing the error.

My first idea was to not wipe the buffer (as by default it would hide), but that seems to have been a conscious decision addressing a different problem.

So instead, I've gone with checking whether a buffer exists before displaying it in a window, and creating a new buffer if the previous buffer has been wiped.