### PR TITLE
feat: add output_panel.clear()

### DIFF
--- a/doc/neotest.txt
+++ b/doc/neotest.txt
@@ -446,6 +446,14 @@ Toggle the output panel
   lua require("neotest").output_panel.toggle()
 <
 
+                                                  *neotest.output_panel.clear()*
+`clear`()
+
+Clears the output panel
+>vim
+  lua require("neotest").output_panel.clear()
+<
+
 
 ==============================================================================
 neotest.run                                                        *neotest.run*

--- a/lua/neotest/consumers/output_panel/init.lua
+++ b/lua/neotest/consumers/output_panel/init.lua
@@ -6,6 +6,10 @@ local OutputPanel = require("neotest.consumers.output_panel.panel")
 ---@type neotest.OutputPanel
 local panel
 
+---@private
+---@type number
+local chan
+
 local neotest = {}
 
 ---@toc_entry Output Panel Consumer
@@ -19,7 +23,6 @@ neotest.output_panel = {}
 local init = function(client)
   panel = OutputPanel(client)
 
-  local chan
   ---@param results table<string, neotest.Result>
   client.listeners.results = function(adapter_id, results, partial)
     if partial then
@@ -80,6 +83,16 @@ function neotest.output_panel.toggle()
     neotest.output_panel.close()
   else
     neotest.output_panel.open()
+  end
+end
+
+--- Clears the output panel
+--- >vim
+---   lua require("neotest").output_panel.clear()
+--- <
+function neotest.output_panel.clear()
+  if chan then
+    vim.api.nvim_chan_send(chan, "\x1b[H\x1b[2J")
   end
 end
 

--- a/lua/neotest/consumers/output_panel/init.lua
+++ b/lua/neotest/consumers/output_panel/init.lua
@@ -6,10 +6,6 @@ local OutputPanel = require("neotest.consumers.output_panel.panel")
 ---@type neotest.OutputPanel
 local panel
 
----@private
----@type number
-local chan
-
 local neotest = {}
 
 ---@toc_entry Output Panel Consumer
@@ -23,6 +19,7 @@ neotest.output_panel = {}
 local init = function(client)
   panel = OutputPanel(client)
 
+  local chan
   ---@param results table<string, neotest.Result>
   client.listeners.results = function(adapter_id, results, partial)
     if partial then
@@ -91,9 +88,9 @@ end
 ---   lua require("neotest").output_panel.clear()
 --- <
 function neotest.output_panel.clear()
-  if chan then
-    vim.api.nvim_chan_send(chan, "\x1b[H\x1b[2J")
-  end
+  nio.api.nvim_buf_set_option(panel.win:buffer(), "modifiable", true)
+  nio.api.nvim_buf_set_lines(panel.win:buffer(), 0, -1, false, {})
+  nio.api.nvim_buf_set_option(panel.win:buffer(), "modifiable", false)
 end
 
 neotest.output_panel = setmetatable(neotest.output_panel, {

--- a/plugin/neotest.lua
+++ b/plugin/neotest.lua
@@ -16,6 +16,7 @@ local cmd_completion_store = {
     "open",
     "close",
     "toggle",
+    "clear",
   },
   run = {
     "file",
@@ -77,6 +78,9 @@ commands = {
     end,
     toggle = function()
       require("neotest").output_panel.toggle()
+    end,
+    clear = function()
+      require("neotest").output_panel.clear()
     end,
   },
   run = {


### PR DESCRIPTION
Often while re-running tests it's hard to see what is output of the current run and output of the last run.

By manually wiring clear() into my bindings I can choose when to clear and when not.