### PR TITLE
refactor!: remove nvim-treesitter dependency

### DIFF
--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -18,27 +18,29 @@ jobs:
 
   tests:
     name: tests
-    runs-on: ubuntu-20.04
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
         include:
-          - os: ubuntu-20.04
-            url: https://github.com/neovim/neovim/releases/download/v0.7.0/nvim-linux64.tar.gz
+          - os: ubuntu-22.04
+            rev: nightly/nvim-linux64.tar.gz
+          - os: ubuntu-22.04
+            rev: v0.9.1/nvim-linux64.tar.gz
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - run: date +%F > todays-date
       - name: Restore cache for today's nightly.
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: _neovim
-          key: ${{ runner.os }}-x64-${{ hashFiles('todays-date') }}
+          key: ${{ runner.os }}-${{ matrix.rev }}-${{ hashFiles('todays-date') }}
 
       - name: Prepare dependencies
         run: |
           test -d _neovim || {
             mkdir -p _neovim
-            curl -sL ${{ matrix.url }} | tar xzf - --strip-components=1 -C "${PWD}/_neovim"
+            curl -sL "https://github.com/neovim/neovim/releases/download/${{ matrix.rev }}" | tar xzf - --strip-components=1 -C "${PWD}/_neovim"
           }
           mkdir -p ~/.local/share/nvim/site/pack/vendor/start
           git clone --depth 1 https://github.com/nvim-lua/plenary.nvim ~/.local/share/nvim/site/pack/vendor/start/plenary.nvim

--- a/README.md
+++ b/README.md
@@ -45,7 +45,6 @@ Install with your favourite package manager alongside nvim-dap
 
 ```vim
 call dein#add("nvim-lua/plenary.nvim")
-call dein#add("nvim-treesitter/nvim-treesitter")
 call dein#add("antoinemadec/FixCursorHold.nvim")
 call dein#add("nvim-neotest/neotest")
 ```
@@ -54,7 +53,6 @@ call dein#add("nvim-neotest/neotest")
 
 ```vim
 Plug 'nvim-lua/plenary.nvim'
-Plug 'nvim-treesitter/nvim-treesitter'
 Plug 'antoinemadec/FixCursorHold.nvim'
 Plug 'nvim-neotest/neotest'
 ```
@@ -66,7 +64,6 @@ use {
   "nvim-neotest/neotest",
   requires = {
     "nvim-lua/plenary.nvim",
-    "nvim-treesitter/nvim-treesitter",
     "antoinemadec/FixCursorHold.nvim"
   }
 }
@@ -79,7 +76,6 @@ use {
   "nvim-neotest/neotest",
   dependencies = {
     "nvim-lua/plenary.nvim",
-    "nvim-treesitter/nvim-treesitter",
     "antoinemadec/FixCursorHold.nvim"
   }
 }

--- a/lua/neotest/lib/subprocess.lua
+++ b/lua/neotest/lib/subprocess.lua
@@ -66,7 +66,6 @@ function neotest.lib.subprocess.init()
       { parent_address }
     )
     -- Load dependencies
-    nio.fn.rpcrequest(child_chan, "nvim_exec_lua", "require('nvim-treesitter')", {})
     nio.fn.rpcrequest(child_chan, "nvim_exec_lua", "require('plenary')", {})
     enabled = true
     nio.api.nvim_create_autocmd("VimLeavePre", { callback = cleanup })

--- a/lua/neotest/lib/treesitter/init.lua
+++ b/lua/neotest/lib/treesitter/init.lua
@@ -114,7 +114,7 @@ end
 function neotest.lib.treesitter.get_parse_root(file_path, content, opts)
   local fast = opts.fast ~= false
   local ft = lib.files.detect_filetype(file_path)
-  local lang = require("nvim-treesitter.parsers").ft_to_lang(ft)
+  local lang = vim.treesitter.language.get_lang(ft) or ft
   nio.scheduler()
   local lang_tree = vim.treesitter.get_string_parser(
     content,

--- a/tests/minimal_init.lua
+++ b/tests/minimal_init.lua
@@ -3,6 +3,7 @@ vim.notify = print
 vim.opt.rtp:append(".")
 vim.opt.rtp:append(lazypath .. "/plenary.nvim")
 vim.opt.rtp:append(lazypath .. "/nvim-dap")
+vim.opt.rtp:append(lazypath .. "/nvim-treesitter")
 vim.opt.swapfile = false
 A = function(...)
   print(vim.inspect(...))

--- a/tests/minimal_init.lua
+++ b/tests/minimal_init.lua
@@ -3,7 +3,6 @@ vim.notify = print
 vim.opt.rtp:append(".")
 vim.opt.rtp:append(lazypath .. "/plenary.nvim")
 vim.opt.rtp:append(lazypath .. "/nvim-dap")
-vim.opt.rtp:append(lazypath .. "/nvim-treesitter")
 vim.opt.swapfile = false
 A = function(...)
   print(vim.inspect(...))


### PR DESCRIPTION
Nvim-treesitter's 1.0 rewrite will remove all utilities/functionality it provides since vim.treesitter pretty much covers it all now,  you can read more in the *main* branch's readme (default is master)

