### PR TITLE
docs(README): link to neotest-java

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ See the adapter's documentation for their specific setup instructions.
 | scala           |    [neotest-scala](https://github.com/stevanmilic/neotest-scala)     |
 | haskell         |    [neotest-haskell](https://github.com/mrcjkb/neotest-haskell)      |
 | deno            |    [neotest-deno](https://github.com/MarkEmmons/neotest-deno)        |
-| java            |    [neotest-java](https://github.com/andy-bell101/neotest-java)      |
+| java            |    [neotest-java](https://github.com/rcasia/neotest-java)      |
 | foundry         |    [neotest-foundry](https://github.com/llllvvuu/neotest-foundry)    |
 
 For any runner without an adapter you can use [neotest-vim-test](https://github.com/nvim-neotest/neotest-vim-test) which supports any runner that vim-test supports.


### PR DESCRIPTION
Hi, I have created an adapter for java and I would like to link it.

I'm not sure how to solve this. Also I'm new to OSS contributions.
A couple of weeks ago, I found there was another adapter for java, which it's not quite working.

I have been slowly developing neotest-java in my free time because I intended to use it in my day to day workflow and I have been testing it on my projects.

So much thanks for neotest! :heart: 