### PR TITLE
Check if file exists before calling is_test_file

### DIFF
--- a/lua/neotest/client/init.lua
+++ b/lua/neotest/client/init.lua
@@ -394,6 +394,11 @@ function neotest.Client:_start(args)
 
   autocmd({ "BufAdd", "BufWritePost" }, function()
     local file_path = vim.fn.expand("<afile>:p")
+
+    if not lib.files.exists(file_path) then
+      return
+    end
+
     nio.run(function()
       local adapter_id = self:_get_adapter(file_path)
       if not adapter_id then
@@ -459,6 +464,11 @@ function neotest.Client:_start(args)
 
   autocmd("BufEnter", function()
     local path = vim.fn.expand("<afile>:p")
+
+    if not lib.files.exists(path) then
+      return
+    end
+
     nio.run(function()
       self:_set_focused_file(path)
     end)
@@ -466,6 +476,11 @@ function neotest.Client:_start(args)
 
   autocmd({ "CursorHold", "BufEnter" }, function()
     local path, line = vim.fn.expand("<afile>:p"), vim.fn.line(".")
+
+    if not lib.files.exists(path) then
+      return
+    end
+
     nio.run(function()
       local pos, pos_adapter_id = self:get_nearest(path, line - 1)
       if not pos then


### PR DESCRIPTION
I'm using neotest-dotnet while also using vim-fugitive and I've noticed that it breaks when I open a fugitive file (i.e. I'll open a diff on the current file with `:Gdiffsplit`). This is because the fugitive diff file (starting with `fugitive:///...`) doesn't exist on disk and neotest-dotnet attempts to load it while being asked if it's a test file.

Some steps to reproduce:
1. Run tests in a test file using neotest-dotnet
2. `:Gdiffsplit`

You'll see this:

```
Error executing luv callback:                                                                                                                                                                                     
/Users/tim/.local/share/nvim/lazy/neotest/lua/nio/tasks.lua:95: Async task failed without callback: The coroutine failed with this message:                                                                       
...al/share/nvim/lazy/neotest/lua/neotest/lib/file/init.lua:24: ENOENT: no such file or directory: fugitive:///.../Tests.cs   
stack traceback:                                                                                                                                                                                                  
        [C]: in function 'assert'                                                                                                                                                                                 
        ...al/share/nvim/lazy/neotest/lua/neotest/lib/file/init.lua:24: in function 'read'                                                                                                                        
        ...are/nvim/lazy/neotest-dotnet/lua/neotest-dotnet/init.lua:26: in function 'is_test_file'                                                                                                                
        ...al/share/nvim/lazy/neotest/lua/neotest/adapters/init.lua:63: in function 'adapter_matching_path'                                                                                                       
        ...ocal/share/nvim/lazy/neotest/lua/neotest/client/init.lua:414: in function <...ocal/share/nvim/lazy/neotest/lua/neotest/client/init.lua:397>                                                            
stack traceback:                                                                                                                                                                                                  
        [C]: in function 'error'                                                                                                                                                                                  
        /Users/tim/.local/share/nvim/lazy/neotest/lua/nio/tasks.lua:95: in function 'close_task'                                                                                                                  
        /Users/tim/.local/share/nvim/lazy/neotest/lua/nio/tasks.lua:117: in function 'cb'                                                                                                                         
        /Users/tim/.local/share/nvim/lazy/neotest/lua/nio/tasks.lua:181: in function </Users/tim/.local/share/nvim/lazy/neotest/lua/nio/tasks.lua:180>
```

This could obviously be fixed in neotest-dotnet, but I've checked against neotest-jest too, and while neotest-jest doesn't break like neotest-dotnet (it doesn't attempt to read the file) it still receives a request to check if the fugitive file is a test file, which it thinks it is since it has a matching filename. I thought it would be best if neotest itself ensured that files existed on disk before asking the adapter if they were test files, or attempting to update test positions.

This PR checks that all files exist on disk before acting on them, i.e. updating positions, etc.