### PR TITLE
status: only place marks for tests with their own range

### DIFF
--- a/lua/neotest/consumers/status.lua
+++ b/lua/neotest/consumers/status.lua
@@ -15,7 +15,7 @@ local function init(client)
 
   local namespace = nio.api.nvim_create_namespace(sign_group)
 
-  local function place_sign(buf, pos, range, adapter_id, results)
+  local function place_sign(buf, pos, adapter_id, results)
     local status
     if results[pos.id] then
       local result = results[pos.id]
@@ -28,12 +28,12 @@ local function init(client)
     end
     if config.status.signs then
       nio.fn.sign_place(0, sign_group, "neotest_" .. status, pos.path, {
-        lnum = range[1] + 1,
+        lnum = pos.range[1] + 1,
         priority = 1000,
       })
     end
     if config.status.virtual_text then
-      nio.api.nvim_buf_set_extmark(buf, namespace, range[1], 0, {
+      nio.api.nvim_buf_set_extmark(buf, namespace, pos.range[1], 0, {
         virt_text = {
           { statuses[status].text .. " ", statuses[status].texthl },
         },
@@ -53,9 +53,8 @@ local function init(client)
         end
         for _, node in tree:iter_nodes() do
           local pos = node:data()
-          local range = node:closest_value_for("range")
-          if pos.type ~= "file" then
-            place_sign(nio.fn.bufnr(file_path), pos, range, adapter_id, results)
+          if pos.range ~= nil and pos.type ~= "file" then
+            place_sign(nio.fn.bufnr(file_path), pos, adapter_id, results)
           end
         end
       end


### PR DESCRIPTION
This fixes #305, by ensuring that rangeless tests will not have markers written at all, avoiding overwriting their parent's mark.

This does introduce another, less significant, issue: the marker for a test will always indicate the result of the last time that the parent test was explicitly executed, including being absent if the parent test has never been specifically requested.  (Currently, this likely only occurs when using the summary window, so users can reference that for more precise result info.  This could become a more annoying issue with, for example, a "run all failed tests" command in future which might bypass parent test execution.)