### PR TITLE
ci: fix luarocks-release workflow

### DIFF
--- a/.github/workflows/luarocks-release.yaml
+++ b/.github/workflows/luarocks-release.yaml
@@ -1,17 +1,29 @@
+---
 on:
   release:
-    types: [published]
+    types:
+      - created
+  push:
+    tags:
+      - '*'
+  workflow_dispatch: # Allow manual trigger
+  pull_request: # Tests the luarocks installation without releasing on PR
 
 jobs:
   luarocks-upload:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Get Version 
+        # tags do not trigger the workflow when they are created by other workflows or releases
+        run: echo "LUAROCKS_VERSION=$(git describe --abbrev=0 --tags)" >> $GITHUB_ENV
       - name: LuaRocks Upload
-        uses: nvim-neorocks/luarocks-tag-release@v4
+        uses: nvim-neorocks/luarocks-tag-release@v5
         env:
           LUAROCKS_API_KEY: ${{ secrets.LUAROCKS_API_KEY }}
-    with:
-      dependencies: |
-        plenary.nvim
-        nvim-treesitter
+        with:
+          version: ${{ env.LUAROCKS_VERSION }}
+          dependencies: |
+            plenary.nvim


### PR DESCRIPTION
This fixes the luarocks release workflow:

- Removes treesitter from the dependencies
- Makes sure the workflow can be triggered by GitHub releases