### PR TITLE
feat(watcher): add symbol queries for ruby rspec tests

### DIFF
--- a/lua/neotest/config/init.lua
+++ b/lua/neotest/config/init.lua
@@ -313,6 +313,22 @@ local default_config = {
         end
         return symbols
       end,
+      ruby = [[
+        ;query
+        ;rspec - class name
+        (call
+          method: (identifier) @_ (#match? @_ "^(describe|context)")
+          arguments: (argument_list (constant) @symbol )
+        )
+
+        ;rspec - namespaced class name
+        (call
+          method: (identifier)
+          arguments: (argument_list
+            (scope_resolution
+              name: (constant) @symbol))
+        )
+      ]],
     },
     filter_path = nil,
   },


### PR DESCRIPTION
I've been using these symbols queries via ruby-lsp[^1] on a Ruby on Rails RSpec application for the past few weeks with success. The watcher feature is so useful!

Most RSpec classes look like this:

```ruby
RSpec.describe MyClass do
  it "my first test" do
    # ...
  end
end
```

It also covers name spaced modules like so, `MyClass` is the returned symbol.

```ruby
RSpec.describe NameSpaceModule1::NameSpace2::MyClass do
  it "my first test" do
    # ...
  end
end
```

References:
[^1]: https://github.com/Shopify/ruby-lsp