### PR TITLE
fix: opening summary window freezes when subprocess finds swap file

### DIFF
--- a/lua/neotest/lib/subprocess.lua
+++ b/lua/neotest/lib/subprocess.lua
@@ -38,7 +38,7 @@ function neotest.lib.subprocess.init()
     logger.error("Failed to start server: " .. parent_address)
     return
   end
-  local cmd = { vim.loop.exepath(), "--embed", "--headless" }
+  local cmd = { vim.loop.exepath(), "--embed", "--headless", "-n" }
   logger.info("Starting child process with command: " .. table.concat(cmd, " "))
   success, child_chan = pcall(nio.fn.jobstart, cmd, {
     rpc = true,


### PR DESCRIPTION
Hi! 👋

I've been having a bug for a while which happened seemingly randomly: sometimes when toggling the test summary window, Neovim would freeze completely, forcing a kill + restart of the process.

Steps were the following:
- `nvim`
- `:lua require('neotest').summary.toggle()`
- freeze happens

I found the hanging line with some trial and error, `subprocess.lua:41` which tries to load neotest in the nvim subprocess and blocks until it gets a response. The fix I found is to spawn the nvim subprocess with swap files disabled.

I have the `Shatur/neovim-session-manager` plugin installed, and it is configured (by default) to open the last opened session when running `nvim` without providing a file/dir argument. At some point after toggling the summary window, the nvim subprocess is spawned with `nvim --embed --headless` re-using the user's config. What I suspect is happening: this subprocess will open the last opened session and open the same files as the main instance, which causes it to error on swap file conflicts and somehow prevent the RPC call to complete. `-n` nvim CLI flag tells the subprocess to ignore swap files, and after including it + manual testing I've seen no freeze yet with the above scenario.

I tried to reproduce the freeze in other ways, by editing my nvim config to throw errors on startup only for the subprocess, but no freeze with those scenarios. 