### PR TITLE
fix: nvim-dap hijacks summary window when using the debug mapping

### DIFF
--- a/lua/neotest/client/runner.lua
+++ b/lua/neotest/client/runner.lua
@@ -116,6 +116,7 @@ function TestRunner:_run_spec(spec, tree, args, adapter_id, adapter, results_cal
   local position = tree:data()
   local context = {
     position = position,
+    adapter = adapter,
   }
 
   local proc_key = self:_create_process_key(adapter_id, position.id)

--- a/lua/neotest/types/init.lua
+++ b/lua/neotest/types/init.lua
@@ -42,6 +42,7 @@ M.ResultStatus = {
 
 ---@class neotest.StrategyContext
 ---@field position neotest.Position
+---@field adapter neotest.Adapter
 
 ---@alias neotest.Strategy async fun(spec: neotest.RunSpec, context: neotest.StrategyContext): neotest.Process
 


### PR DESCRIPTION
![neotest-hijack-bug](https://github.com/nvim-neotest/neotest/assets/53346834/4bed9365-735a-44c1-95ad-f243561ac08f)

## Bug

Whenever the debug mapping is used inside the summary window and a breakpoint is hit, nvim-dap hijacks the summary window to focus the breakpoint.

## Repro

- Set config option `switchbuf = 'uselast'` in nvim-dap (default)
- Open test file
- Set a breakpoint in test
- Open + move to summary window
- Use debug mapping `d` on test

## Expected

The window containing the test buffer should be used to focus the breakpoint.

## Fix

`nvim-dap` has the `switchbuf` config option to to control how a breakpoint is jumped to, the default is `uselast` and it probably makes the most sense as a default for neotest too. It works like this: when `dap.run()` is executed, if the current buffer is a normal buffer or `dap.run()` is not provided with a different `filetype` than the current buffer, then the current window is used to focus the breakpoint, otherwise the previous (`#`) window is used. Initially `filetype` was not provided, so the current window was picked.

The change broke some tests due to async related issues. I'm not familiar with async lua so I didn't dive too deep, I saw some sleep hacks being thrown around in tests so I replicated that and it fixed them, lmk if that should be handled differently.

