### PR TITLE
Output close mapping

### DIFF
--- a/lua/neotest/config/init.lua
+++ b/lua/neotest/config/init.lua
@@ -105,6 +105,7 @@ define_highlights()
 ---@class neotest.Config.output
 ---@field enabled boolean
 ---@field open_on_run string|boolean Open nearest test result after running
+---@field close_mapping string|boolean key to map the close action
 
 ---@class neotest.Config.state
 ---@field enabled boolean
@@ -241,6 +242,7 @@ local default_config = {
   output = {
     enabled = true,
     open_on_run = "short",
+    close_mapping = false,
   },
   output_panel = {
     enabled = true,
@@ -384,7 +386,7 @@ function NeotestConfigModule.setup_project(project_root, config)
     default_strategy = user_config.default_strategy,
   })
   user_config.projects[path].discovery.concurrent =
-    convert_concurrent(user_config.projects[path].discovery.concurrent)
+      convert_concurrent(user_config.projects[path].discovery.concurrent)
   local logger = require("neotest.logging")
   logger.info("Project", path, "configuration complete")
   logger.debug("Project config", user_config.projects[path])

--- a/lua/neotest/consumers/output.lua
+++ b/lua/neotest/consumers/output.lua
@@ -56,16 +56,16 @@ local function open_output(result, opts)
   end
 
   opts.open_win = opts.open_win
-    or function(win_opts)
-      local float = lib.ui.float.open({
-        width = win_opts.width,
-        height = win_opts.height,
-        buffer = buf,
-        auto_close = opts.auto_close,
-      })
-      float:listen("close", on_close)
-      return float.win_id
-    end
+      or function(win_opts)
+        local float = lib.ui.float.open({
+          width = win_opts.width,
+          height = win_opts.height,
+          buffer = buf,
+          auto_close = opts.auto_close,
+        })
+        float:listen("close", on_close)
+        return float.win_id
+      end
 
   local cur_win = vim.api.nvim_get_current_win()
 
@@ -84,6 +84,9 @@ local function open_output(result, opts)
   end
 
   vim.api.nvim_buf_set_option(buf, "filetype", "neotest-output")
+  if config.output.close_mapping then
+    vim.api.nvim_buf_set_keymap(buf, "n", config.output.close_mapping, on_close, { noremap = true, silent = true })
+  end
 end
 
 local neotest = {}
@@ -115,11 +118,11 @@ local init = function()
         local pos = node:data()
         local range = node:closest_value_for("range")
         if
-          pos.type == "test"
-          and results[pos.id]
-          and results[pos.id].status == "failed"
-          and range[1] <= line
-          and range[3] >= line
+            pos.type == "test"
+            and results[pos.id]
+            and results[pos.id].status == "failed"
+            and range[1] <= line
+            and range[3] >= line
         then
           open_output(
             results[pos.id],

--- a/lua/neotest/consumers/output.lua
+++ b/lua/neotest/consumers/output.lua
@@ -64,12 +64,13 @@ local function open_output(result, opts)
           auto_close = opts.auto_close,
         })
         float:listen("close", on_close)
-        return float.win_id
+        return float
       end
 
   local cur_win = vim.api.nvim_get_current_win()
 
-  win = opts.open_win({ width = width, height = height }) or vim.api.nvim_get_current_win()
+  local float = opts.open_win({ width = width, height = height }) or vim.api.nvim_get_current_win()
+  win = float.win_id
 
   vim.api.nvim_create_autocmd("WinClosed", {
     pattern = tostring(win),
@@ -84,8 +85,17 @@ local function open_output(result, opts)
   end
 
   vim.api.nvim_buf_set_option(buf, "filetype", "neotest-output")
+
   if config.output.close_mapping then
-    vim.api.nvim_buf_set_keymap(buf, "n", config.output.close_mapping, on_close, { noremap = true, silent = true })
+    vim.keymap.set("n", config.output.close_mapping, "", {
+      buffer = buf,
+      desc = "closes the output popup",
+      noremap = true,
+      silent = true,
+      callback = function()
+        float:close(true)
+      end
+    })
   end
 end
 


### PR DESCRIPTION
Hey there, when accessed via `Summary`, output pop up get focused and the only way of quitting it is to change to another window/buffer. I found that odd and kind of annoying, so I'm adding a configurable mapping (disabled by default, so we don't have any changes on the current behavior) for closing the output pop up when it is the current focused window / buffer.