### PR TITLE
doc: add neotest-bash adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ See the adapter's documentation for their specific setup instructions.
 | haskell         |    [neotest-haskell](https://github.com/mrcjkb/neotest-haskell)      |
 | deno            |    [neotest-deno](https://github.com/MarkEmmons/neotest-deno)        |
 | java            |    [neotest-java](https://github.com/rcasia/neotest-java)      |
+| bash            |    [neotest-bash](https://github.com/rcasia/neotest-bash)            |
 | foundry         |    [neotest-foundry](https://github.com/llllvvuu/neotest-foundry)    |
 | zig             |    [neotest-zig](https://github.com/lawrence-laz/neotest-zig)    |
 


### PR DESCRIPTION
Adds [neotest-bash](https://github.com/rcasia/neotest-bash) to README.