### PR TITLE
doc(readme): add neotest-gtest

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,29 +87,30 @@ See the adapter's documentation for their specific setup instructions.
 ### Supported Runners
 
 | Test Runner     |                               Adapter                                |
-| :-------------- | :------------------------------------------------------------------: |
-| pytest          |   [neotest-python](https://github.com/nvim-neotest/neotest-python)   |
-| python-unittest |   [neotest-python](https://github.com/nvim-neotest/neotest-python)   |
-| plenary         |  [neotest-plenary](https://github.com/nvim-neotest/neotest-plenary)  |
-| go              |         [neotest-go](https://github.com/akinsho/neotest-go)          |
-| jest            |     [neotest-jest](https://github.com/haydenmeade/neotest-jest)      |
-| vitest          |     [neotest-vitest](https://github.com/marilari88/neotest-vitest)   |
-| playwright      |  [neotest-playwright](https://github.com/thenbe/neotest-playwright)  |
-| rspec           |     [neotest-rspec](https://github.com/olimorris/neotest-rspec)      |
-| minitest        |   [neotest-minitest](https://github.com/zidhuss/neotest-minitest)    |
-| dart, flutter   |       [neotest-dart](https://github.com/sidlatau/neotest-dart)       |
-| testthat        | [neotest-testthat](https://github.com/shunsambongi/neotest-testthat) |
-| phpunit         |   [neotest-phpunit](https://github.com/olimorris/neotest-phpunit)    |
-| pest            | [neotest-pest](https://github.com/theutz/neotest-pest)               |
-| rust            |        [neotest-rust](https://github.com/rouge8/neotest-rust)        |
-| elixir          |    [neotest-elixir](https://github.com/jfpedroza/neotest-elixir)     |
-| dotnet          |    [neotest-dotnet](https://github.com/Issafalcon/neotest-dotnet)    |
-| scala           |    [neotest-scala](https://github.com/stevanmilic/neotest-scala)     |
-| haskell         |    [neotest-haskell](https://github.com/mrcjkb/neotest-haskell)      |
-| deno            |    [neotest-deno](https://github.com/MarkEmmons/neotest-deno)        |
-| java            |    [neotest-java](https://github.com/rcasia/neotest-java)      |
-| foundry         |    [neotest-foundry](https://github.com/llllvvuu/neotest-foundry)    |
-| zig             |    [neotest-zig](https://github.com/lawrence-laz/neotest-zig)    |
+| :---------------- | :------------------------------------------------------------------: |
+| pytest            |   [neotest-python](https://github.com/nvim-neotest/neotest-python)   |
+| python-unittest   |   [neotest-python](https://github.com/nvim-neotest/neotest-python)   |
+| plenary           |  [neotest-plenary](https://github.com/nvim-neotest/neotest-plenary)  |
+| go                |         [neotest-go](https://github.com/akinsho/neotest-go)          |
+| jest              |     [neotest-jest](https://github.com/haydenmeade/neotest-jest)      |
+| vitest            |     [neotest-vitest](https://github.com/marilari88/neotest-vitest)   |
+| playwright        |  [neotest-playwright](https://github.com/thenbe/neotest-playwright)  |
+| rspec             |     [neotest-rspec](https://github.com/olimorris/neotest-rspec)      |
+| minitest          |   [neotest-minitest](https://github.com/zidhuss/neotest-minitest)    |
+| dart, flutter     |       [neotest-dart](https://github.com/sidlatau/neotest-dart)       |
+| testthat          | [neotest-testthat](https://github.com/shunsambongi/neotest-testthat) |
+| phpunit           |   [neotest-phpunit](https://github.com/olimorris/neotest-phpunit)    |
+| pest              | [neotest-pest](https://github.com/theutz/neotest-pest)               |
+| rust              |        [neotest-rust](https://github.com/rouge8/neotest-rust)        |
+| elixir            |    [neotest-elixir](https://github.com/jfpedroza/neotest-elixir)     |
+| dotnet            |    [neotest-dotnet](https://github.com/Issafalcon/neotest-dotnet)    |
+| scala             |    [neotest-scala](https://github.com/stevanmilic/neotest-scala)     |
+| haskell           |    [neotest-haskell](https://github.com/mrcjkb/neotest-haskell)      |
+| deno              |    [neotest-deno](https://github.com/MarkEmmons/neotest-deno)        |
+| java              |    [neotest-java](https://github.com/rcasia/neotest-java)            |
+| foundry           |    [neotest-foundry](https://github.com/llllvvuu/neotest-foundry)    |
+| zig               |    [neotest-zig](https://github.com/lawrence-laz/neotest-zig)        |
+| c++ (google test) |    [neotest-gtest](https://github.com/alfaix/neotest-gtest)          |
 
 For any runner without an adapter you can use [neotest-vim-test](https://github.com/nvim-neotest/neotest-vim-test) which supports any runner that vim-test supports.
 The vim-test adapter does not support some of the more advanced features such as error locations or per-test output.


### PR DESCRIPTION
Adding [neotest-gtest](https://github.com/alfaix/neotest-gtest) to the list as it's now more-or-less functional.

Also wanted to mention - I wrote integration tests while working on the plugin, they allow writing tests like [this](https://github.com/alfaix/neotest-gtest/blob/main/tests/integration/plugin_spec.lua#L27) from files like [this](https://github.com/alfaix/neotest-gtest/blob/main/tests/integration/cpp/src/test_one.cpp#L13). Would it make sense to contribute the testing tools to this plugin? Of course, `configure_executable` and things like that don't make sense for other adapters, but I think the general "write test project" -> "ensure it's running" flow would help with testing.