### PR TITLE
fix: allow terminating tests run through dap strategy

### DIFF
--- a/lua/neotest/client/strategies/dap/init.lua
+++ b/lua/neotest/client/strategies/dap/init.lua
@@ -103,6 +103,9 @@ return function(spec, context)
     attach = function()
       dap.repl.open()
     end,
+    stop = function()
+      dap.terminate()
+    end,
     result = function()
       finish_future:wait()
       return result_code


### PR DESCRIPTION
Currently, it is not possible to stop a test running through the debug strategy (by calling `require("neotest").run.stop()`.

This results in the following error:
```
E5108: Error executing lua: ...quitlox/.local/share/nvim/lazy/neotest/lua/nio/tasks.lua:95: Async task failed without callback: Th
e coroutine failed with this message:                                                                                             
...nvim/lazy/neotest/lua/neotest/client/strategies/init.lua:66: attempt to call field 'stop' (a nil value)                        
stack traceback:                                                                                                                  
        ...nvim/lazy/neotest/lua/neotest/client/strategies/init.lua: in function 'stop'                                           
        ...al/share/nvim/lazy/neotest/lua/neotest/client/runner.lua:205: in function 'stop'                                       
        ...ocal/share/nvim/lazy/neotest/lua/neotest/client/init.lua:123: in function 'stop'                                       
        ...al/share/nvim/lazy/neotest/lua/neotest/consumers/run.lua:148: in function 'func'                                       
        ...quitlox/.local/share/nvim/lazy/neotest/lua/nio/tasks.lua:168: in function <...quitlox/.local/share/nvim/lazy/neotest/lu
a/nio/tasks.lua:167>                                                                                                              
stack traceback:                                                                                                                  
        [C]: in function 'error'                                                                                                  
        ...quitlox/.local/share/nvim/lazy/neotest/lua/nio/tasks.lua:95: in function 'close_task'                                  
        ...quitlox/.local/share/nvim/lazy/neotest/lua/nio/tasks.lua:117: in function 'step'                                       
        ...quitlox/.local/share/nvim/lazy/neotest/lua/nio/tasks.lua:145: in function 'stop'                                       
        ...itlox/.config/nvim/lua/quitlox/plugins/ide/test/init.lua:30: in function <...itlox/.config/nvim/lua/quitlox/plugins/ide
/test/init.lua:30>  
```

This PR adds the `stop` method to the dap strategy.