### PR TITLE
feat(watcher): symbol queries for haskell and rust

### DIFF
--- a/lua/neotest/config/init.lua
+++ b/lua/neotest/config/init.lua
@@ -340,6 +340,34 @@ local default_config = {
               name: (constant) @symbol))
         )
       ]],
+      rust = [[
+        ;query
+        ;submodule import
+        (mod_item
+          name: (identifier) @symbol)
+        ;single import
+        (use_declaration
+          argument: (scoped_identifier
+            name: (identifier) @symbol))
+        ;import list
+        (use_declaration
+          argument: (scoped_use_list
+            list: (use_list
+                [(scoped_identifier
+                   path: (identifier)
+                   name: (identifier) @symbol)
+                 ((identifier) @symbol)])))
+        ;wildcard import
+        (use_declaration
+          argument: (scoped_use_list
+            path: (identifier)
+            [(use_list
+              [(scoped_identifier
+                path: (identifier)
+                name: (identifier) @symbol)
+                ((identifier) @symbol)
+              ])]))
+      ]],
     },
     filter_path = nil,
   },

--- a/lua/neotest/config/init.lua
+++ b/lua/neotest/config/init.lua
@@ -368,6 +368,17 @@ local default_config = {
                 ((identifier) @symbol)
               ])]))
       ]],
+      haskell = [[
+        ;query
+        ;explicit import
+        ((import_item [(variable)]) @symbol)
+        ;symbols that may be imported implicitly
+        ((type) @symbol)
+        (qualified_variable (variable) @symbol)
+        (exp_apply (exp_name (variable) @symbol))
+        ((constructor) @symbol)
+        ((operator) @symbol)
+      ]],
     },
     filter_path = nil,
   },

--- a/lua/neotest/consumers/watch/watcher.lua
+++ b/lua/neotest/consumers/watch/watcher.lua
@@ -63,7 +63,10 @@ function Watcher:_get_linked_files(path, root_path, args)
     end
 
     for _, def in ipairs(defs or {}) do
-      dependency_uris[def.uri or def.targetUri] = true
+      local index = def.uri or def.targetUri
+      if index then
+        dependency_uris[def.uri or def.targetUri] = true
+      end
     end
   end
   local paths = { path }


### PR DESCRIPTION
- Add queries for Haskell
- Add queries for Rust
- Fix an error that is thrown if no definitions are found for a set of queries