### PR TITLE
feat(watch): allow passing in `run_predicate` that takes a bufnr

### DIFF
--- a/lua/neotest/consumers/watch/init.lua
+++ b/lua/neotest/consumers/watch/init.lua
@@ -76,16 +76,24 @@ local default_args = {
   end,
 }
 
+---@class neotest.watch.WatchArgs: neotest.run.RunArgs
+---@field run_predicate? fun(bufnr: integer):boolean Can be used to check whether tests should be rerun
+
 --- Watch a position and run it whenever related files are changed.
 --- Arguments are the same as the `neotest.run.run`, which allows
 --- for custom runner arguments, env vars, strategy etc. If a position is
 --- already being watched, the existing watcher will be stopped.
----@param args? neotest.run.RunArgs|string
+--- An additional `run_predicate` function, which takes a buffer handle,
+--- can be passed in to determine whether tests should be rerun.
+--- This can be useful, e.g. for only rerunning if there are no LSP
+--- error diagnostics.
+---@param args? neotest.watch.WatchArgs|string
 function neotest.watch.watch(args)
   args = args or {}
   if type(args) == "string" then
     args = { args }
   end
+  ---@cast args neotest.watch.WatchArgs
   args = vim.tbl_extend("keep", args, default_args)
 
   local run = require("neotest").run
@@ -131,7 +139,7 @@ neotest.watch.watch = nio.create(neotest.watch.watch, 1)
 --- ```vim
 ---   lua require("neotest").watch.toggle(vim.fn.expand("%"))
 --- ```
----@param args? neotest.run.RunArgs|string
+---@param args? neotest.watch.WatchArgs|string
 function neotest.watch.toggle(args)
   local run = require("neotest").run
   local tree = run.get_tree_from_args(args, false)

--- a/lua/neotest/consumers/watch/watcher.lua
+++ b/lua/neotest/consumers/watch/watcher.lua
@@ -80,7 +80,7 @@ function Watcher:_get_linked_files(path, root_path, args)
   return paths
 end
 
----@class neotest.consumers.watch.watcher.WatchArgs
+---@class neotest.consumers.watch.watcher.WatchArgs: neotest.watch.WatchArgs
 ---@field filter_path fun(root: string, path: string): boolean
 
 ---@paam tree neotest.Tree
@@ -146,6 +146,8 @@ function Watcher:_build_dependants(dependencies)
   return dependants
 end
 
+---@param tree neotest.Tree
+---@param args neotest.consumers.watch.watcher.WatchArgs
 function Watcher:watch(tree, args)
   local run = require("neotest").run
   local paths = self:_files_in_tree(tree)
@@ -159,6 +161,9 @@ function Watcher:watch(tree, args)
 
   self.autocmd_id = nio.api.nvim_create_autocmd("BufWritePost", {
     callback = function(autocmd_args)
+      if type(args.run_predicate) == "function" and not args.run_predicate(autocmd_args.buf) then
+        return
+      end
       nio.run(function()
         local path = nio.fn.expand(nio.api.nvim_buf_get_name(autocmd_args.buf), ":p")
 


### PR DESCRIPTION
This is useful e.g. for checking if the buffer has any error diagnostics from the LSP client, in which case one would probably not want to rerun the tests yet.