### PR TITLE
fix(find): Use full path instead of real path to avoid symlinks

### DIFF
--- a/lua/neotest/lib/file/init.lua
+++ b/lua/neotest/lib/file/init.lua
@@ -230,7 +230,7 @@ neotest.lib.files.path = {
   sep = neotest.lib.files.sep,
   exists = neotest.lib.files.exists,
   real = function(path)
-    local normalized_path = vim.fn.fnamemodify(path, ":p")
+    local normalized_path = nio.fn.fnamemodify(path, ":p")
     local exists = neotest.lib.files.exists(normalized_path)
     return exists and normalized_path or nil, exists
   end,

--- a/lua/neotest/lib/file/init.lua
+++ b/lua/neotest/lib/file/init.lua
@@ -230,8 +230,9 @@ neotest.lib.files.path = {
   sep = neotest.lib.files.sep,
   exists = neotest.lib.files.exists,
   real = function(path)
-    local err, real = nio.uv.fs_realpath(path)
-    return real, err
+    local normalized_path = vim.fn.fnamemodify(path, ":p")
+    local exists = neotest.lib.files.exists(normalized_path)
+    return exists and normalized_path or nil, exists
   end,
 }
 


### PR DESCRIPTION
When a respository is in a symlink-ed path (eg: larger hard-drive for projects w/ small SDD for OS), calling `nio.uv.fs_realpath` will perform symlink resolution. https://github.com/nvim-neotest/neotest/blob/f6048f32be831907fb15018af2688ff6633704fc/lua/neotest/lib/file/init.lua#L233

Given the following scenario, nvim will run buffers with the home-dir path, instead of the resolved symlink path.

```sh
ln -s $HOME/projects /mnt/largehdd/projets
cd $HOME/projects/my_project
nvim .
```

Then, the following lua code will result on 2 different filenames.
```lua
local path_name = vim.api.nvim_buf_get_name(0) -- /home/me/projects/my_project/src/lib.rs
neotest.lib.files.path.real(path_name) -- /mnt/largehdd/projects/my_project/src/lib.rs
```

When sending the fully resolved symlinked path to a plugin, the `path_name` on the plugin will not match any of the path names of buffers, if they perform a search or use an external process.

This causes issues on `rustaceanvim` LSP-based test detection, which requires the file to be on the root of the LSP runner directory, and thus, the `file_path` sent is rejected.

This commit changes the login of `neotest.lib.files.path.real` to use the vim function for resolving the full path name, followed by an exists check, as there is 1 function usage that requires the error checking present.

Now, the following code is the same, and resolves the `No tests found!` when running `:Neotest run file` using `rustaceanvim` on a symlinked project folder (I know, niche...).

```lua
local path_name = vim.api.nvim_buf_get_name(0) -- /home/me/projects/my_project/src/lib.rs
neotest.lib.files.path.real(path_name) -- /home/me/projects/my_project/src/lib.rs
```