### PR TITLE
Add help key to summary panel to show mappings

### DIFF
--- a/lua/neotest/config/init.lua
+++ b/lua/neotest/config/init.lua
@@ -233,6 +233,7 @@ local default_config = {
       next_failed = "J",
       prev_failed = "K",
       watch = "w",
+      help = "?",
     },
   },
   benchmark = {

--- a/lua/neotest/consumers/summary/component.lua
+++ b/lua/neotest/consumers/summary/component.lua
@@ -233,30 +233,37 @@ function SummaryComponent:_render(canvas, tree, expanded, focused, indent)
       neotest.summary.clear_marked({ adapter = self.adapter_id })
     end)
 
-    canvas:add_mapping("help", async_func(function()
-      local help_text = {
-        "SUMMARY MAPPINGS",
-        "================",
-      }
-      for name, mapping in pairs(config.summary.mappings) do
-        local mappings = type(mapping) == "table" and table.concat(mapping, ", ") or mapping
-        local line = "(" .. name .. "): " .. mappings
-        table.insert(help_text, line)
-      end
+    canvas:add_mapping(
+      "help",
+      async_func(function()
+        local help_text = {}
+        local width = 0
+        for name, mapping in pairs(config.summary.mappings) do
+          local mappings = type(mapping) == "table" and table.concat(mapping, ", ") or mapping
+          local line = "(" .. name .. "): " .. mappings
+          width = math.max(width, #line)
+          table.insert(help_text, line)
+        end
 
-      local buf = vim.api.nvim_create_buf(false, true)
-      vim.api.nvim_buf_set_lines(buf, 0, -1, false, help_text)
-      vim.api.nvim_buf_set_option(buf, "modifiable", false)
-      local float = lib.ui.float.open({
-        width = 80,
-        height = 60,
-        buffer = buf,
-        auto_close = true,
-      })
-      local win = float.win_id
-      vim.api.nvim_win_set_buf(win, buf)
-      vim.api.nvim_set_current_win(win)
-    end))
+        table.insert(help_text, 1, "Mappings")
+        width = math.max(width, #help_text[1])
+        table.insert(help_text, 2, string.rep("=", width))
+
+        local buf = vim.api.nvim_create_buf(false, true)
+        vim.api.nvim_buf_set_lines(buf, 0, -1, false, help_text)
+        vim.api.nvim_buf_set_option(buf, "modifiable", false)
+        local float = lib.ui.float.open({
+          width = width,
+          height = #help_text,
+          buffer = buf,
+          auto_close = true,
+        })
+        local win = float.win_id
+        vim.api.nvim_win_set_buf(win, buf)
+        vim.api.nvim_set_current_win(win)
+        vim.api.nvim_buf_set_keymap(buf, "n", "q", "<cmd>q<CR>", { noremap = true, silent = true })
+      end)
+    )
 
     local status = self:_get_status(position)
     has_running = has_running or status == "running"

--- a/lua/neotest/consumers/summary/component.lua
+++ b/lua/neotest/consumers/summary/component.lua
@@ -233,6 +233,31 @@ function SummaryComponent:_render(canvas, tree, expanded, focused, indent)
       neotest.summary.clear_marked({ adapter = self.adapter_id })
     end)
 
+    canvas:add_mapping("help", async_func(function()
+      local help_text = {
+        "SUMMARY MAPPINGS",
+        "================",
+      }
+      for name, mapping in pairs(config.summary.mappings) do
+        local mappings = type(mapping) == "table" and table.concat(mapping, ", ") or mapping
+        local line = "(" .. name .. "): " .. mappings
+        table.insert(help_text, line)
+      end
+
+      local buf = vim.api.nvim_create_buf(false, true)
+      vim.api.nvim_buf_set_lines(buf, 0, -1, false, help_text)
+      vim.api.nvim_buf_set_option(buf, "modifiable", false)
+      local float = lib.ui.float.open({
+        width = 80,
+        height = 60,
+        buffer = buf,
+        auto_close = true,
+      })
+      local win = float.win_id
+      vim.api.nvim_win_set_buf(win, buf)
+      vim.api.nvim_set_current_win(win)
+    end))
+
     local status = self:_get_status(position)
     has_running = has_running or status == "running"
 


### PR DESCRIPTION
Adds a binding (default `?`) to the summary panel that shows the list of key mappings.

Fixes #230

I'm not very familiar with lua and neovim plugin dev so this might not be the best way to implement it. The mappings are just shown as text and it's not very readable but I don't know how to format the text to make it look better.