### PR TITLE
fix(luarocks): add nio to rockspec dependencies

### DIFF
--- a/.github/workflows/luarocks-release.yaml
+++ b/.github/workflows/luarocks-release.yaml
@@ -27,3 +27,4 @@ jobs:
           version: ${{ env.LUAROCKS_VERSION }}
           dependencies: |
             plenary.nvim
+            nvim-nio


### PR DESCRIPTION
We found a way to fix the issue of the luarocks workflow not being triggered by the release tag: You can add a personal access token (see [this tutorial](https://github.com/nvim-neorocks/sample-luarocks-plugin?tab=readme-ov-file#generating-a-pat-personal-access-token)).