### PR TITLE
docs(readme): add StencilJS adapter to list

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ See the adapter's documentation for their specific setup instructions.
 | go                |         [neotest-go](https://github.com/akinsho/neotest-go)          |
 | jest              |     [neotest-jest](https://github.com/haydenmeade/neotest-jest)      |
 | vitest            |    [neotest-vitest](https://github.com/marilari88/neotest-vitest)    |
+| stenciljs         |  [neotest-stenciljs](https://github.com/benelan/neotest-stenciljs)   |
 | playwright        |  [neotest-playwright](https://github.com/thenbe/neotest-playwright)  |
 | rspec             |     [neotest-rspec](https://github.com/olimorris/neotest-rspec)      |
 | minitest          |   [neotest-minitest](https://github.com/zidhuss/neotest-minitest)    |


### PR DESCRIPTION
StencilJS is a frontend framework for creating web components, similar to Lit. It has a builtin test runner that uses Jest and Puppeteer under the hood.  Credit goes to neotest-jest, which provided a great starting point for neotest-stenciljs!

adapter: https://github.com/benelan/neotest-stenciljs
stencil: https://github.com/ionic-team/stencil
ref: https://stenciljs.com/docs/testing/stencil-testrunner/overview