### PR TITLE
fix: check buffer valid before set diagnostic

### DIFF
--- a/lua/neotest/consumers/diagnostic.lua
+++ b/lua/neotest/consumers/diagnostic.lua
@@ -55,6 +55,7 @@ local function init(client)
     logger.debug("Setting diagnostics for", self.file_path, diagnostics)
 
     vim.schedule(function()
+      if not vim.api.nvim_buf_is_valid(self.bufnr) then return end
       diag.set(diag_namespace, self.bufnr, diagnostics)
     end)
   end


### PR DESCRIPTION
The error happens when deleting the buffer.