### PR TITLE
feat(config): setup adapters with function

### DIFF
--- a/doc/neotest.txt
+++ b/doc/neotest.txt
@@ -219,7 +219,7 @@ neotest.config                                                  *neotest.config*
 
                                                             *neotest.CoreConfig*
 Fields~
-{adapters} `(neotest.Adapter[])`
+{adapters} `(neotest.Adapter[]|fun():neotest.Adapter[])`
 {discovery} `(neotest.Config.discovery)`
 {running} `(neotest.Config.running)`
 {default_strategy} `(string|function)`

--- a/lua/neotest/config/init.lua
+++ b/lua/neotest/config/init.lua
@@ -42,7 +42,7 @@ local js_watch_query = [[
 ]]
 
 ---@class neotest.CoreConfig
----@field adapters (neotest.Adapter[]|fun(): neotest.Adapter[])
+---@field adapters neotest.Adapter[]|fun():neotest.Adapter[]
 ---@field discovery neotest.Config.discovery
 ---@field running neotest.Config.running
 ---@field default_strategy string|function

--- a/lua/neotest/config/init.lua
+++ b/lua/neotest/config/init.lua
@@ -42,7 +42,7 @@ local js_watch_query = [[
 ]]
 
 ---@class neotest.CoreConfig
----@field adapters neotest.Adapter[]
+---@field adapters (neotest.Adapter[]|fun(): neotest.Adapter[])
 ---@field discovery neotest.Config.discovery
 ---@field running neotest.Config.running
 ---@field default_strategy string|function
@@ -432,6 +432,10 @@ function NeotestConfigModule.setup(config)
     user_config.discovery,
     { concurrent = convert_concurrent(user_config.discovery.concurrent) }
   )
+
+  if type(user_config.adapters) == "function" then
+    user_config.adapters = user_config.adapters()
+  end
 
   user_config.projects = setmetatable({}, {
     __index = function()


### PR DESCRIPTION
Hey :wave:

I have a problem with setting up the plugin with lazy.nvim's opts because it would load adapters at the same time they weren't loaded, and because of that, I would fail. It might be prevented by wrapping adapters setup in function, so I made it.


The solution looks like this:
```lua
{
  "nvim-neotest/neotest",
  opts = {
    -- now `adapters` can be set up to {} as previously or to a function that will return {} of adapters
    adapters = function()
      return {
        require "neotest-plenary",
        require "neotest-go",
      }
    end,
  }
}
```

Also I believe it might help set up adapters on different conditions