### PR TITLE
feat(client): show stacktrace information when adapter fails

### DIFF
--- a/lua/neotest/client/init.lua
+++ b/lua/neotest/client/init.lua
@@ -80,19 +80,17 @@ function neotest.Client:run_tree(tree, args)
     return
   end
   self._state:update_running(adapter_id, root.id, pos_ids)
-  local success, all_results = pcall(
-    self._runner.run_tree,
-    self._runner,
-    tree,
-    args,
-    adapter_id,
-    adapter,
-    function(results)
+  local errmsg = ""
+  local success, all_results = xpcall(function()
+    return self._runner.run_tree(self._runner, tree, args, adapter_id, adapter, function(results)
       self._state:update_results(adapter_id, results, true)
-    end
-  )
+    end)
+  end, function(err)
+    errmsg = debug.traceback(err, 1)
+  end)
+
   if not success then
-    lib.notify(("%s: %s"):format(adapter.name, all_results), "warn")
+    lib.notify(("%s: %s"):format(adapter.name, errmsg), "warn")
     all_results = {}
     for _, pos in tree:iter() do
       all_results[pos.id] = { status = "skipped" }


### PR DESCRIPTION
Problem: Warning messages via `vim.notify` do not retain stack trace,
which makes errors or bugs happened on the adapters' side difficult
to troubleshoot. E.g.:

```
    neotest-python: vim/_editor.lua:0: E5560: Vimscript function must not be called in a lua loop callback
```

Solution: Use `xpcall`, instead of `pcall` to access the stacktrace
information, and use it when showing warning (error) messages. E.g.:
