### PR TITLE
Fixed empty neotest in Neovim master branch (0.10+)

### DIFF
--- a/lua/neotest/types/tree.lua
+++ b/lua/neotest/types/tree.lua
@@ -2,6 +2,9 @@ local fu = require("neotest.lib.func_util")
 
 local neotest = {}
 
+-- NOTE: Needed until compatibility with Neovim 0.9 is dropped
+local islist = vim.fn.has('nvim-0.10') == 1 and vim.islist or vim.tbl_islist
+
 --- Nested tree structure with nodes containing data and having any
 --- number of children
 ---@class neotest.Tree
@@ -64,7 +67,7 @@ end
 function neotest.Tree._from_list(data, key, parent, nodes)
   local node_key
   local node
-  if vim.tbl_islist(data) then
+  if islist(data) then
     local node_data = data[1]
     node_key = key(node_data)
     local children = {}


### PR DESCRIPTION
If you load the root of a project (not a test file), Neotest doesn't seem to ever populate.

![image](https://github.com/nvim-neotest/neotest/assets/10103049/15e1ed5d-2e01-41cb-9202-d382c453f885)

If you then open a test file, you get this warning:

```
vim.tbl_islist is deprecated, use vim.islist instead. :help deprecated
Feature will be removed in Nvim 0.12
stack traceback:
        vim/shared.lua: in function 'tbl_islist'
        ...l/.config/nvim/bundle/neotest/lua/neotest/types/tree.lua:67: in function '_from_list'
        ...l/.config/nvim/bundle/neotest/lua/neotest/types/tree.lua:40: in function 'from_list'
        .../nvim/bundle/neotest/lua/neotest/lib/treesitter/init.lua:198: in function 'discover_positions'
        .../.config/nvim/bundle/neotest/lua/neotest/client/init.lua:300: in function <.../.config/nvim/bundle/neotest/lua/neotest/client/init.lua:264>
        [C]: in function 'xpcall'
        .../.config/nvim/bundle/neotest/lua/neotest/client/init.lua:264: in function '_update_positions'
        .../.config/nvim/bundle/neotest/lua/neotest/client/init.lua:438: in function <.../.config/nvim/bundle/neotest/lua/neotest/client/init.lua:400>
```

This PR fixes both issues.