### PR TITLE
Add neotest-golang to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ See the adapter's documentation for their specific setup instructions.
 | pytest            |   [neotest-python](https://github.com/nvim-neotest/neotest-python)   |
 | python-unittest   |   [neotest-python](https://github.com/nvim-neotest/neotest-python)   |
 | plenary           |  [neotest-plenary](https://github.com/nvim-neotest/neotest-plenary)  |
-| go                |         [neotest-go](https://github.com/akinsho/neotest-go)          |
+| go                |         [neotest-go](https://github.com/akinsho/neotest-go) <br> [neotest-golang](https://github.com/fredrikaverpil/neotest-golang) |
 | jest              |     [neotest-jest](https://github.com/haydenmeade/neotest-jest)      |
 | vitest            |    [neotest-vitest](https://github.com/marilari88/neotest-vitest)    |
 | stenciljs         |  [neotest-stenciljs](https://github.com/benelan/neotest-stenciljs)   |


### PR DESCRIPTION
I've made another adapter for Go, in [`fredrikaverpil/neotest-golang`](https://github.com/fredrikaverpil/neotest-golang), as I was having a lot of issues with the one listed in the README. My adapter outlines those problems [here](https://github.com/fredrikaverpil/neotest-golang#neotest-go-issues-mitigated-in-neotest-golang).

I figured it could be helpful for others to list my adapter as an alternative, for others who might also have issues with the currently listed Go adapter. 😄 