### PR TITLE
fix: Use buffered stdout in the integrated strategy

### DIFF
--- a/lua/neotest/client/strategies/integrated/init.lua
+++ b/lua/neotest/client/strategies/integrated/init.lua
@@ -37,6 +37,7 @@ return function(spec)
     cwd = cwd,
     env = env,
     pty = true,
+    stdout_buffered = true,
     height = spec.strategy.height,
     width = spec.strategy.width,
     on_stdout = function(_, data)


### PR DESCRIPTION
When I ran Golang tests for a whole suite (or for a file), I often encountered that either the plugin hung up or (if using `library`) I was getting the error message:
```
neotest-golang: ...i.zotov/.local/share/nvim/lazy/nvim-nio/lua/nio/init.lua:119: The coroutine failed with this message: Task was cancelled
stack traceback:
        ...ocal/share/nvim/lazy/neotest/lua/neotest/client/init.lua:89: in function <...ocal/share/nvim/lazy/neotest/lua/neotest/client/init.lua:88>
        [C]: in function 'error'
        ...i.zotov/.local/share/nvim/lazy/nvim-nio/lua/nio/init.lua:119: in function 'gather'
        ...al/share/nvim/lazy/neotest/lua/neotest/client/runner.lua:153: in function '_run_broken_down_tree'
        ...al/share/nvim/lazy/neotest/lua/neotest/client/runner.lua:79: in function '_run_tree'
        ...al/share/nvim/lazy/neotest/lua/neotest/client/runner.lua:65: in function <...al/share/nvim/lazy/neotest/lua/neotest/client/runner.lua:22>
        [C]: in function 'xpcall'
        ...ocal/share/nvim/lazy/neotest/lua/neotest/client/init.lua:84: in function 'run_tree'
        ...al/share/nvim/lazy/neotest/lua/neotest/consumers/run.lua:73: in function 'func'
        ....zotov/.local/share/nvim/lazy/nvim-nio/lua/nio/tasks.lua:173: in function <....zotov/.local/share/nvim/lazy/nvim-nio/lua/nio/tasks.lua:172>
```

Turns out, that output of commands running in the background sometimes breaks due to not writing the whole thing. I added an option to use buffered output when running commands, so no output is lost when written to a temporary file.