### PR TITLE
fix: no autocommand file name to substitute for <afile>

### DIFF
--- a/lua/neotest/client/init.lua
+++ b/lua/neotest/client/init.lua
@@ -390,8 +390,8 @@ function neotest.Client:_start(args)
     })
   end
 
-  autocmd({ "BufAdd", "BufWritePost" }, function()
-    local file_path = vim.fn.expand("<afile>:p")
+  autocmd({ "BufAdd", "BufWritePost" }, function(ev)
+    local file_path = vim.fn.fnamemodify(ev.file, ":p")
 
     if not lib.files.exists(file_path) then
       return
@@ -446,8 +446,8 @@ function neotest.Client:_start(args)
     end)
   end)
 
-  autocmd({ "BufAdd", "BufDelete" }, function()
-    local updated_dir = vim.fn.expand("<afile>:p:h")
+  autocmd({ "BufAdd", "BufDelete" }, function(ev)
+    local updated_dir = vim.fn.fnamemodify(ev.file, ":p:h")
     nio.run(function()
       local adapter_id = self:_get_adapter(updated_dir, nil)
       if not adapter_id then
@@ -460,8 +460,8 @@ function neotest.Client:_start(args)
     end)
   end)
 
-  autocmd("BufEnter", function()
-    local path = vim.fn.expand("<afile>:p")
+  autocmd("BufEnter", function(ev)
+    local path = vim.fn.fnamemodify(ev.file, ":p")
 
     if not lib.files.exists(path) then
       return
@@ -473,7 +473,7 @@ function neotest.Client:_start(args)
   end)
 
   autocmd({ "CursorHold", "BufEnter" }, function()
-    local path, line = vim.fn.expand("<afile>:p"), vim.fn.line(".")
+    local path, line = vim.fn.expand("%:p"), vim.fn.line(".")
 
     if not lib.files.exists(path) then
       return


### PR DESCRIPTION
I encountered a bunch of error in Neotest when I started Neovim in verbose mode (`nvim -V1`), coming from these autocmds. Turns out, when `expand()` fails in verbose mode it will throw an error instead of expanding to the empty string (see https://github.com/neovim/neovim/issues/29175). You can reproduce the issue using the minimal init file below:

```lua
-- save as repro.lua
-- run with nvim -V1 -u repro.lua
local root = vim.fn.fnamemodify("./.repro", ":p")

-- set stdpaths to use .repro
for _, name in ipairs({ "config", "data", "state", "runtime", "cache" }) do
  vim.env[("XDG_%s_HOME"):format(name:upper())] = root .. "/" .. name
end

vim.g.mapleader = " "
-- bootstrap lazy
local lazypath = root .. "/plugins/lazy.nvim"
if not vim.loop.fs_stat(lazypath) then
  vim.fn.system({
    "git",
    "clone",
    "--filter=blob:none",
    "--single-branch",
    "https://github.com/folke/lazy.nvim.git",
    lazypath,
  })
end
vim.opt.runtimepath:prepend(lazypath)

-- install plugins
local plugins = {
  {
    "nvim-treesitter/nvim-treesitter",
    config = function()
      require("nvim-treesitter.configs").setup({
        ensure_installed = {
          "python",
        },
        auto_install = true,
      })
    end,
  },
  {
    "nvim-neotest/neotest",
    dependencies = {
      "nvim-lua/plenary.nvim",
      "nvim-neotest/neotest-python",
      "nvim-neotest/nvim-nio",
      "nvim-treesitter/nvim-treesitter",
    },
    keys = {
      {
        "<leader>tf",
        function()
          require("neotest").run.run({ vim.api.nvim_buf_get_name(0) })
        end,
        desc = "[T]est [F]ile",
      },
    },
    config = function()
      require("neotest").setup({
        adapters = {
          require("neotest-python")({}),
        },
      })
    end,
  },
  -- add any other plugins here
}
require("lazy").setup(plugins, {
  root = root .. "/plugins",
})
```

To see the errors, do
1. `nvim -V1 -u repro.lua test.py` (test.py is just some python file with a test)
2. `<leader>tf` to run tests
3. `:tabnew`

```
Error detected while processing BufAdd Autocommands for "*":
Error executing lua callback: Vim:E495: No autocommand file name to substitute for "<afile>"
stack traceback:
        [C]: in function 'expand'
        ...e/tmp/.repro/plugins/neotest/lua/neotest/client/init.lua:394: in function <...e/tmp/.repro/plugins/neotest/lua/neotest/client/init.lua:393>
Error executing lua callback: Vim:E495: No autocommand file name to substitute for "<afile>"
stack traceback:
        [C]: in function 'expand'
        ...e/tmp/.repro/plugins/neotest/lua/neotest/client/init.lua:450: in function <...e/tmp/.repro/plugins/neotest/lua/neotest/client/init.lua:449>
Error detected while processing BufEnter Autocommands for "*":
Error executing lua callback: Vim:E495: No autocommand file name to substitute for "<afile>"
stack traceback:
        [C]: in function 'expand'
        ...e/tmp/.repro/plugins/neotest/lua/neotest/client/init.lua:464: in function <...e/tmp/.repro/plugins/neotest/lua/neotest/client/init.lua:463>
Error executing lua callback: Vim:E495: No autocommand file name to substitute for "<afile>"
stack traceback:
        [C]: in function 'expand'
        ...e/tmp/.repro/plugins/neotest/lua/neotest/client/init.lua:476: in function <...e/tmp/.repro/plugins/neotest/lua/neotest/client/init.lua:475>
```

The workaround I'm applying here is to use the data in the autocmd callback to get the `afile` instead of calling `expand()`