### PR TITLE
fix: properly handle nil value from cpu_info()

### DIFF
--- a/lua/neotest/client/strategies/init.lua
+++ b/lua/neotest/client/strategies/init.lua
@@ -13,9 +13,11 @@ end
 local ProcessTracker = {}
 
 function ProcessTracker:new()
+  -- Hack for Android devices, where cpu_info() returns nil
+  local cpu_info = vim.loop.cpu_info() or {}
   local tracker = {
     _instances = {},
-    _process_semaphore = nio.control.semaphore(#vim.loop.cpu_info() + 4),
+    _process_semaphore = nio.control.semaphore(#cpu_info + 4),
   }
   self.__index = self
   setmetatable(tracker, self)

--- a/lua/neotest/config/init.lua
+++ b/lua/neotest/config/init.lua
@@ -419,7 +419,9 @@ local NeotestConfigModule = {}
 
 local convert_concurrent = function(val)
   if val == 0 or val == true then
-    return #vim.loop.cpu_info() + 4
+    -- Hack for Android devices, where cpu_info() returns nil
+    local cpu_info = vim.loop.cpu_info() or {}
+    return #cpu_info + 4
   end
   if val == false then
     return 1


### PR DESCRIPTION
On Android devices, the function `vim.loop.cpu_info()` returns a nil value, since it is unable to read from `/proc` for security reasons. We should handle that failure properly in Neotest and avoid panicking.