### PR TITLE
chore(window): replace deprecated usage nvim_buf_set_option

### DIFF
--- a/lua/neotest/lib/window.lua
+++ b/lua/neotest/lib/window.lua
@@ -68,7 +68,7 @@ function PersistentWindow:buffer()
   nio.api.nvim_buf_set_name(self._bufnr, self.name)
   for k, v in pairs(self._bufopts) do
     if k ~= "filetype" then
-      nio.api.nvim_buf_set_option(self._bufnr, k, v)
+      nio.api.nvim_set_option_value(k, v, { buf = self._bufnr })
     end
   end
   return self._bufnr


### PR DESCRIPTION
this is now deprecated in 0.10 and can be replaced with nvim_set_option_value

per https://neovim.io/doc/user/deprecated.html#deprecated-0.10

Fixes: N/A