### PR TITLE
fix: don't crawl cwd when adding a new buffer

### DIFF
--- a/lua/neotest/client/init.lua
+++ b/lua/neotest/client/init.lua
@@ -391,6 +391,10 @@ function neotest.Client:_start(args)
   end
 
   autocmd({ "BufAdd", "BufWritePost" }, function(ev)
+    -- Don't update positions when saving or creating non-file buffers
+    if ev.file == "" then
+      return
+    end
     local file_path = vim.fn.fnamemodify(ev.file, ":p")
 
     if not lib.files.exists(file_path) then


### PR DESCRIPTION
If you recall a long time ago I advocated for the option to set `discovery.enabled = false` because I work with a large repo and crawling it for tests causes Neovim to be nearly frozen for 20+ minutes while pegging the CPU. I noticed this behavior again recently, and tracked it down to this:
https://github.com/nvim-neotest/neotest/blob/32ff2ac21135a372a42b38ae131e531e64833bd3/lua/neotest/client/init.lua#L393-L398

For me, this was happening when I opened the quickfix, but the key is just that `BufAdd` was getting triggered for a non-file buffer. This lead to `ev.file` being an empty string, and when you pass that in to fnamemodify you get `vim.fn.fnamemodify("", ":p")` which returns your current directory. It looks like the intent of this autocmd is to check for changes to existing files or creation of new files and re-searching the parent directory for tests. What was actually happening was we were passing that `file_path` into `self._update_positions` lower down in that function

https://github.com/nvim-neotest/neotest/blob/32ff2ac21135a372a42b38ae131e531e64833bd3/lua/neotest/client/init.lua#L438

Which resulted in a recursive search originating from the current working directory.

The fix that I opted to put in here was just to early return if the `ev.file` is an empty string, since it seems like neotest probably shouldn't care about those buffers.