### PR TITLE
Fix `lib.process.run` stall

### DIFF
--- a/lua/neotest/lib/process/init.lua
+++ b/lua/neotest/lib/process/init.lua
@@ -41,9 +41,6 @@ function neotest.lib.process.run(command, args)
     error(pid)
   end
 
-  local result_code = exit_future.wait()
-  handle:close()
-
   local stdout_data, stderr_data
   if args.stdout then
     stdout_data = ""
@@ -71,6 +68,9 @@ function neotest.lib.process.run(command, args)
     end)
     read_future.wait()
   end
+
+  local result_code = exit_future.wait()
+  handle:close()
 
   stdin:close()
   stdout:close()


### PR DESCRIPTION
This issue manifested itself it a weird way. While testing an adapter, I noticed that the process I was running to list tests via the underlying test runner would stall if there were too many tests being run. If I commented out some tests the process suddenly finished fine without stalling. If it stalled, I could kill the process and the adapter would start responding again. Subsequent runs would yield "No tests found".

I believe the issue is related to I/O buffering of stdout/stderr and the fact that the process is waited on immediately after spawning it.

Consider a case where the output to stderr fits within the buffer:

1. Spawn process.
2. Wait for process to finish.
3. Process outputs to stderr then finishes.
4. `exit_future.set` is called.
5. stderr is read via `read_start`.

Then consider a case where the output to stderr is larger than the buffer (e.g. when listing a lof of tests):

1. Spawn process.
2. Wait for process to finish.
3. Process outputs to stderr.
4. No more data can fit in the buffer so the process waits.

We are waiting for the process to finish and the process is waiting for someone to consume the output to stderr so it can write more data to stderr but since reading from stderr happens *after* waiting for the process to be done, `lib.process.run` has essentially deadlocked itself indefinitely. Moving the call to `exit_future.wait()` to after the reads of stdout/stderr caused the process to instantly finish and the adapter was working again.

I ran `lldb`, attached to the running process, and ran `thread backtrace` and as you can see from the output below, the process is waiting to write. I let the process continue, then interrupted it to dump a backtrace multiple times with the same result. While this is not solid evidence of the issue, it is a strong indication. The process also does not consume any CPU during the stall.

```shell
(lldb) attach 93252
Process 93252 stopped
* thread #1, queue = 'com.apple.main-thread', stop reason = signal SIGSTOP
    frame #0: 0x00007fff202f829e libsystem_kernel.dylib`__write_nocancel + 10
libsystem_kernel.dylib`__write_nocancel:
->  0x7fff202f829e <+10>: jae    0x7fff202f82a8            ; <+20>
    0x7fff202f82a0 <+12>: movq   %rax, %rdi
    0x7fff202f82a3 <+15>: jmp    0x7fff202f5ab9            ; cerror_nocancel
    0x7fff202f82a8 <+20>: retq
Target 0: (nvim) stopped.

Executable module set to "/opt/local/bin/nvim".
Architecture set to: x86_64h-apple-macosx-.

(lldb) thread backtrace
* thread #1, queue = 'com.apple.main-thread', stop reason = signal SIGSTOP
  * frame #0: 0x00007fff202f829e libsystem_kernel.dylib`__write_nocancel + 10
    frame #1: 0x00007fff202400a9 libsystem_c.dylib`_swrite + 87
    frame #2: 0x00007fff2023b132 libsystem_c.dylib`__sfvwrite + 500
    frame #3: 0x00007fff20239b9b libsystem_c.dylib`fputs + 96
    frame #4: 0x0000000100a22b7d nvim`msg_puts_attr_len + 781
    frame #5: 0x0000000100a1d2a2 nvim`msg_outtrans_len_attr + 1250
    frame #6: 0x0000000100a1c916 nvim`msg_attr_keep + 422
    frame #7: 0x00000001009d9231 nvim`nlua_print_event + 145
    frame #8: 0x00000001009d3dd2 nvim`nlua_print + 1490
    frame #9: 0x0000000100f21dab libluajit-5.1.2.dylib`___lldb_unnamed_symbol96$$libluajit-5.1.2.dylib + 68
    frame #10: 0x0000000100f2e699 libluajit-5.1.2.dylib`lua_pcall + 145
    frame #11: 0x00000001009d4f61 nvim`nlua_pcall + 113
    frame #12: 0x00000001009d37c0 nvim`nlua_exec_file + 512
    frame #13: 0x000000010080a84a nvim`main + 16250
    frame #14: 0x00007fff20345f3d libdyld.dylib`start + 1
    frame #15: 0x00007fff20345f3d libdyld.dylib`start + 1
```

This might also explain some of the other "No tests found" issues being reported for adapters that use `lib.process.run` which would be incredibly difficult to debug as the buffer sizes for buffered I/O are dependent on the system/OS, the application, and the size of the output of the process making the bug sporadically manifest itself.