### PR TITLE
fix(query): explicitly opt-in to legacy behavior

### DIFF
--- a/lua/neotest/config/init.lua
+++ b/lua/neotest/config/init.lua
@@ -333,7 +333,7 @@ local default_config = {
           ]]
         )
         local symbols = {}
-        for _, match, metadata in query:iter_matches(root, content) do
+        for _, match, metadata in query:iter_matches(root, content, _, _, { all = false }) do
           for id, node in pairs(match) do
             local name = query.captures[id]
 

--- a/lua/neotest/lib/treesitter/init.lua
+++ b/lua/neotest/lib/treesitter/init.lua
@@ -56,7 +56,7 @@ local function collect(file_path, query, source, root, opts)
       range = { root:range() },
     },
   }
-  for _, match in query:iter_matches(root, source) do
+  for _, match in query:iter_matches(root, source, _, _, { all = false }) do
     local captured_nodes = {}
     for i, capture in ipairs(query.captures) do
       captured_nodes[capture] = match[i]


### PR DESCRIPTION
After https://github.com/neovim/neovim/commit/6913c5e1d975a11262d08b3339d50b579e6b6bb8 in Neovim nightly, neotest returns `No tests found` (tested with `neotest-python`). Since it's mentioned in the PR that the option `all = false` will be removed in the future, maybe a more robust approach would be preferable, but I don't have the knowledge to implement it. This is just a hotfix until someone else comes with something better.