### PR TITLE
feat: use client.supports_method instead of client.server_capabilities

### DIFF
--- a/lua/neotest/consumers/watch/init.lua
+++ b/lua/neotest/consumers/watch/init.lua
@@ -32,9 +32,12 @@ neotest.watch = {}
 local function get_valid_client(bufnr)
   local clients = nio.lsp.get_clients({ bufnr = bufnr })
   for _, client in ipairs(clients) do
-    ---@type nio.lsp.types.ServerCapabilities
-    local caps = client.server_capabilities
-    if caps.definitionProvider then
+    local has_definition_support = client.supports_method
+        and client.supports_method("textDocument/definition")
+      -- for compatibility with Neovim versions earlier than v0.10.1
+      or client.server_capabilities.definitionProvider
+
+    if has_definition_support then
       logger.debug("Found client", client.name, "for watch")
       return client
     end


### PR DESCRIPTION
Fixes #425.

For reference: https://github.com/neovim/neovim/commit/ddd92a70d2aab5247895e89abaaa79c62ba7dbb4.