### PR TITLE
Fix: Test watch won't start on v0.10.1

### DIFF
--- a/lua/neotest/consumers/watch/init.lua
+++ b/lua/neotest/consumers/watch/init.lua
@@ -32,10 +32,13 @@ neotest.watch = {}
 local function get_valid_client(bufnr)
   local clients = nio.lsp.get_clients({ bufnr = bufnr })
   for _, client in ipairs(clients) do
-    local has_definition_support = client.supports_method
-        and client.supports_method("textDocument/definition")
-      -- for compatibility with Neovim versions earlier than v0.10.1
-      or client.server_capabilities.definitionProvider
+    local has_definition_support
+    if client.server_capabilities then
+      -- for compatibility with Neovim versions earlier and equal to v0.10.1
+      has_definition_support = client.server_capabilities.definitionProvider
+    elseif type(client.supports_method) == "function" then
+      has_definition_support = client.supports_method("textDocument/definition")
+    end
 
     if has_definition_support then
       logger.debug("Found client", client.name, "for watch")

--- a/lua/neotest/consumers/watch/init.lua
+++ b/lua/neotest/consumers/watch/init.lua
@@ -38,11 +38,15 @@ local function get_valid_client(bufnr)
       has_definition_support = client.server_capabilities.definitionProvider
     elseif type(client.supports_method) == "function" then
       has_definition_support = client.supports_method("textDocument/definition")
+    else
+      has_definition_support = false
     end
 
     if has_definition_support then
       logger.debug("Found client", client.name, "for watch")
       return client
+    else
+      logger.debug("Client for watch not found")
     end
   end
 end

--- a/lua/neotest/consumers/watch/init.lua
+++ b/lua/neotest/consumers/watch/init.lua
@@ -33,13 +33,12 @@ local function get_valid_client(bufnr)
   local clients = nio.lsp.get_clients({ bufnr = bufnr })
   for _, client in ipairs(clients) do
     local has_definition_support
-    if client.server_capabilities then
-      -- for compatibility with Neovim versions earlier and equal to v0.10.1
-      has_definition_support = client.server_capabilities.definitionProvider
-    elseif type(client.supports_method) == "function" then
-      has_definition_support = client.supports_method("textDocument/definition")
+    if nio.fn.has("nvim-0.10.1") == 0 then
+      -- for compatibility with Neovim versions earlier than v0.10.1
+      has_definition_support = client.server_capabilities ~= nil
+        and client.server_capabilities.definitionProvider
     else
-      has_definition_support = false
+      has_definition_support = client.supports_method.textDocument_definition({ bufnr = bufnr })
     end
 
     if has_definition_support then


### PR DESCRIPTION
On the version v0.10.1, supports_method is still a table, rather than a function. Trying to access the table field as a function resulted in following error:

```
attempt to call field 'supports_method' (a table value)
```

This behavior is now fixed.

