### PR TITLE
fix(query): use `nil` to skip optional parameters when calling the iter_matches method

### DIFF
--- a/lua/neotest/config/init.lua
+++ b/lua/neotest/config/init.lua
@@ -333,7 +333,7 @@ local default_config = {
           ]]
         )
         local symbols = {}
-        for _, match, metadata in query:iter_matches(root, content, _, _, { all = false }) do
+        for _, match, metadata in query:iter_matches(root, content, nil, nil, { all = false }) do
           for id, node in pairs(match) do
             local name = query.captures[id]
 

--- a/lua/neotest/lib/treesitter/init.lua
+++ b/lua/neotest/lib/treesitter/init.lua
@@ -56,7 +56,7 @@ local function collect(file_path, query, source, root, opts)
       range = { root:range() },
     },
   }
-  for _, match in query:iter_matches(root, source, _, _, { all = false }) do
+  for _, match in query:iter_matches(root, source, nil, nil, { all = false }) do
     local captured_nodes = {}
     for i, capture in ipairs(query.captures) do
       captured_nodes[capture] = match[i]


### PR DESCRIPTION
https://github.com/nvim-neotest/neotest/pull/450 sometimes breaks test parsing behavior after changing directories, because we're passing `_` instead of a `nil` value to the `iter_matches` function.
This PR fixes the problem.