### PR TITLE
fix(watcher): race condition between positions update and watch run on BufWritePost

### DIFF
--- a/lua/neotest/consumers/watch/init.lua
+++ b/lua/neotest/consumers/watch/init.lua
@@ -29,6 +29,16 @@ local neotest = {}
 ---@class neotest.consumers.watch
 neotest.watch = {}
 
+local init = function(client)
+  client.listeners.discover_positions = function(_, tree)
+    for _, watcher in pairs(watchers) do
+      if watcher.tree:data().path == tree:data().path then
+        watcher.discover_positions_event.set()
+      end
+    end
+  end
+end
+
 local function get_valid_client(bufnr)
   local clients = nio.lsp.get_clients({ bufnr = bufnr })
   for _, client in ipairs(clients) do
@@ -200,7 +210,8 @@ function neotest.watch.is_watching(position_id)
 end
 
 neotest.watch = setmetatable(neotest.watch, {
-  __call = function()
+  __call = function(_, client)
+    init(client)
     return neotest.watch
   end,
 })


### PR DESCRIPTION
When watching a spec and editing it at the same time, threre are 2 BufWritePost events triggered on file save.  One to update `NeotestClientState:update_positions` and the other for the watcher, which runs the spec.  
If the watcher spec is run before the positions are updated, it is run with the stale tree and there is a mismatch in positions ids.

To fix this: I added a wait for an `discover_positions` event.