### PR TITLE
feat: triggering QuickFixCmdPost event after setting quickfix list

### DIFF
--- a/lua/neotest/consumers/quickfix.lua
+++ b/lua/neotest/consumers/quickfix.lua
@@ -67,6 +67,7 @@ local init = function()
     end)
 
     nio.fn.setqflist(qf_results)
+    vim.cmd.doautocmd("QuickFixCmdPost")
     if #qf_results > 0 then
       if config.quickfix.open then
         if type(config.quickfix.open) == "function" then


### PR DESCRIPTION
This update introduces the triggering of the QuickFixCmdPost event after the quickfix list is set.

The primary purpose of this change is to ensure tools like Trouble can update properly, especially in scenarios where there are no failing tests remaining. 