### PR TITLE
docs: add link to lazydev.nvim for hints/docs

### DIFF
--- a/doc/neotest.txt
+++ b/doc/neotest.txt
@@ -379,7 +379,7 @@ neotest.consumers                                            *neotest.consumers*
 Consumers provide user consumable APIs by wrapping the lower level client
 object. If you are developing a consumer, it is strongly recommended to enable
 type checking of the `neotest` repo, as it will provide very helpful type
-hints/docs. You can use https://github.com/folke/lua-dev.nvim to do this easily.
+hints/docs. You can use https://github.com/folke/lazydev.nvim to do this easily.
 
 A consumer is a function which takes a neotest.Client object. The function can
 optionally return a table containing functions which will be directly accessable

--- a/lua/neotest/consumers/init.lua
+++ b/lua/neotest/consumers/init.lua
@@ -5,7 +5,7 @@ local neotest = {}
 --- Consumers provide user consumable APIs by wrapping the lower level client
 --- object. If you are developing a consumer, it is strongly recommended to enable
 --- type checking of the `neotest` repo, as it will provide very helpful type
---- hints/docs. You can use https://github.com/folke/lua-dev.nvim to do this easily.
+--- hints/docs. You can use https://github.com/folke/lazydev.nvim to do this easily.
 ---
 --- A consumer is a function which takes a neotest.Client object. The function can
 --- optionally return a table containing functions which will be directly accessable


### PR DESCRIPTION
Updated docs to point to https://github.com/folke/lazydev.nvim.