### PR TITLE
fix: watcher unnecessarily waiting for discover position event to be set

### DIFF
--- a/lua/neotest/consumers/watch/watcher.lua
+++ b/lua/neotest/consumers/watch/watcher.lua
@@ -177,7 +177,9 @@ function Watcher:watch(tree, args)
           return
         end
 
-        self.discover_positions_event.wait()
+        if path == tree:data().path then
+          self.discover_positions_event.wait()
+        end
         self.discover_positions_event = nio.control.future()
 
         if tree:data().type ~= "dir" then


### PR DESCRIPTION
#479 introduced a small bug where the watcher would wait for the ```discover_positions_event``` by the listener set up by the init function. This PR fixes it by checking if the changed file is relevant to the discover_position_event.