### PR TITLE
fix: only populate quickfix if we have errors

### DIFF
--- a/lua/neotest/consumers/quickfix.lua
+++ b/lua/neotest/consumers/quickfix.lua
@@ -66,9 +66,9 @@ local init = function()
       return a.filename < b.filename
     end)
 
-    nio.fn.setqflist(qf_results)
-    vim.cmd.doautocmd("QuickFixCmdPost")
     if #qf_results > 0 then
+      nio.fn.setqflist(qf_results)
+      vim.cmd.doautocmd("QuickFixCmdPost")
       if config.quickfix.open then
         if type(config.quickfix.open) == "function" then
           config.quickfix.open()


### PR DESCRIPTION
Currently when you run a test and you've enabled the `quickfix` consumer in your config, it will populate the quickfix list as you would expect. However if you run a test and it passes, it will still populate the quickfix list with an empty list. It makes sense to not override the quickfix list if no errors were raised from the test run.