### PR TITLE
build: use correct targets for neovim builds.

### DIFF
--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -24,7 +24,7 @@ jobs:
       matrix:
         include:
           - os: ubuntu-22.04
-            rev: nightly/nvim-linux64.tar.gz
+            rev: nightly/nvim-linux-x86_64.tar.gz
           - os: ubuntu-22.04
             rev: v0.9.1/nvim-linux64.tar.gz
     steps:


### PR DESCRIPTION
the artifacts used to have the name linux64, but were split into x86_64 and arm64. This should make the nightly builds run successfully.

Fixes: #515