### PR TITLE
feat: build_position provide treesitter node metadata

### DIFF
--- a/lua/neotest/lib/treesitter/init.lua
+++ b/lua/neotest/lib/treesitter/init.lua
@@ -94,7 +94,7 @@ end
 
 ---@class neotest.lib.treesitter.ParseOptions : neotest.lib.positions.ParseOptions
 ---@field fast? boolean Use faster parsing (Should be unchanged unless injections are needed)
----@field build_position? fun(file_path: string, source: string, captured_nodes: table<string, userdata>, metadata: vim.treesitter.query.TSMetadata): neotest.Position|neotest.Position[]|nil Builds one or more positions from the captured nodes from a query match.
+---@field build_position? fun(file_path: string, source: string, captured_nodes: table<string, userdata>, metadata: table<string, vim.treesitter.query.TSMetadata>): neotest.Position|neotest.Position[]|nil Builds one or more positions from the captured nodes from a query match.
 
 --- Build a parsed Query object from a string
 ---@param lang string

--- a/lua/neotest/lib/treesitter/init.lua
+++ b/lua/neotest/lib/treesitter/init.lua
@@ -22,7 +22,7 @@ local function get_match_type(captured_nodes)
   end
 end
 
-local function build_position(file_path, source, captured_nodes)
+local function build_position(file_path, source, captured_nodes, metadata)
   local match_type = get_match_type(captured_nodes)
   if match_type then
     ---@type string
@@ -56,12 +56,14 @@ local function collect(file_path, query, source, root, opts)
       range = { root:range() },
     },
   }
-  for _, match in query:iter_matches(root, source, nil, nil, { all = false }) do
+  for _, match, metadata in query:iter_matches(root, source, nil, nil, { all = false }) do
     local captured_nodes = {}
+    local node_metadata = {}
     for i, capture in ipairs(query.captures) do
       captured_nodes[capture] = match[i]
+      node_metadata[capture] = metadata[i]
     end
-    local res = opts.build_position(file_path, source, captured_nodes)
+    local res = opts.build_position(file_path, source, captured_nodes, node_metadata)
     if res then
       if res[1] then
         for _, pos in ipairs(res) do
@@ -92,7 +94,7 @@ end
 
 ---@class neotest.lib.treesitter.ParseOptions : neotest.lib.positions.ParseOptions
 ---@field fast? boolean Use faster parsing (Should be unchanged unless injections are needed)
----@field build_position? fun(file_path: string, source: string, captured_nodes: table<string, userdata>): neotest.Position|neotest.Position[]|nil Builds one or more positions from the captured nodes from a query match.
+---@field build_position? fun(file_path: string, source: string, captured_nodes: table<string, userdata>, metadata: vim.treesitter.query.TSMetadata): neotest.Position|neotest.Position[]|nil Builds one or more positions from the captured nodes from a query match.
 
 --- Build a parsed Query object from a string
 ---@param lang string


### PR DESCRIPTION
Closes #516 

My specific use case is to allow for appending/prepending text to `@test.name` and `@namespace.name` for [neotest-kotlin](https://github.com/codymikol/neotest-kotlin) where the testing frameworks we're trying to support append text to namespace and test names. See the issue for a complete example!

This is a non-breaking change, as it passes a new arg to `build_position` of TSMetadata which in my personal use case I'll only be using `text` from.

Here's my expected implementation using this new feature

```lua
local function get_match_type(captured_nodes)
  if captured_nodes["test.name"] then
    return "test"
  end
  if captured_nodes["namespace.name"] then
    return "namespace"
  end
end

local function build_position(file_path, source, captured_nodes, metadata)
  local match_type = get_match_type(captured_nodes)
  if match_type then
    ---@type string
    local name = metadata[match_type .. ".name"].text or vim.treesitter.get_node_text(captured_nodes[match_type .. ".name"], source)
    local definition = captured_nodes[match_type .. ".definition"]

    return {
      type = match_type,
      path = file_path,
      name = name,
      range = { definition:range() },
    }
  end
end
```

## Changes

- Provides Treesitter metadata to `build_position`
- Tests for multiple Treesitter directives