### PR TITLE
fix(border): default border to nil to respect winborder

### DIFF
--- a/doc/neotest.txt
+++ b/doc/neotest.txt
@@ -80,7 +80,6 @@ Default values:
       enabled = true
     },
     floating = {
-      border = "rounded",
       max_height = 0.6,
       max_width = 0.6,
       options = {}
@@ -269,7 +268,7 @@ Alias~
 
                                                        *neotest.Config.floating*
 Fields~
-{border} `(string)` Border style
+{border?} `(string)` Border style
 {max_height} `(number)` Max height of window as proportion of NeoVim window
 {max_width} `(number)` Max width of window as proportion of NeoVim window
 {options} `(table)` Window local options to set on floating windows (e.g.

--- a/lua/neotest/config/init.lua
+++ b/lua/neotest/config/init.lua
@@ -77,7 +77,7 @@ local js_watch_query = [[
 ---@alias neotest.Consumer fun(client: neotest.Client): table
 
 ---@class neotest.Config.floating
----@field border string Border style
+---@field border? string Border style
 ---@field max_height number Max height of window as proportion of NeoVim window
 ---@field max_width number Max width of window as proportion of NeoVim window
 ---@field options table Window local options to set on floating windows (e.g. winblend)
@@ -217,7 +217,7 @@ local default_config = {
     watching = "NeotestWatching",
   },
   floating = {
-    border = "rounded",
+    border = nil,
     max_height = 0.6,
     max_width = 0.6,
     options = {},


### PR DESCRIPTION
Problem: winborder is not respected because border is hardcoded to "rounded".

Solution: default to nil which will use winborder if set by the user.

Minor drawback: winborder was added in 0.11, and for users on a version less than this which was just using a default options, they now need to set it. I feel like this is reasonable though, and not assume which border the users want