### PR TITLE
fix(subprocess): add -u NONE to child process command to disable user…

### DIFF
--- a/lua/neotest/lib/subprocess.lua
+++ b/lua/neotest/lib/subprocess.lua
@@ -38,7 +38,7 @@ function neotest.lib.subprocess.init()
     logger.error("Failed to start server: " .. parent_address)
     return
   end
-  local cmd = { vim.loop.exepath(), "--embed", "--headless", "-n" }
+  local cmd = { vim.loop.exepath(), "--embed", "--headless", "-n", "-u", "NONE" }
   logger.info("Starting child process with command: " .. table.concat(cmd, " "))
   success, child_chan = pcall(nio.fn.jobstart, cmd, {
     rpc = true,


### PR DESCRIPTION
… config

This ensures the child Neovim process runs without loading user configuration.

Fixes #441 