### PR TITLE
feat: Support overriding error severity

### DIFF
--- a/lua/neotest/consumers/diagnostic.lua
+++ b/lua/neotest/consumers/diagnostic.lua
@@ -116,7 +116,7 @@ local function init(client)
                   col = col,
                   message = error.message,
                   source = "neotest",
-                  severity = config.diagnostic.severity,
+                  severity = error.severity or config.diagnostic.severity,
                 }
               end
             end

--- a/lua/neotest/types/init.lua
+++ b/lua/neotest/types/init.lua
@@ -31,6 +31,7 @@ M.ResultStatus = {
 ---@class neotest.Error
 ---@field message string
 ---@field line? integer
+---@field severity? integer Diagnostic severity (see vim.diagnostic.severity)
 
 ---@class neotest.Process
 ---@field output async fun(): string Path to file containing output data


### PR DESCRIPTION
This allows error severity to be modified by runners. Particularly useful for runners like `neotest-golang` which would otherwise produce error diagnostics when the test succeeds:

<img width="1239" height="290" alt="image" src="https://github.com/user-attachments/assets/f8a082be-c504-4e69-880f-31e2714f9372" />
