### PR TITLE
feat: add sibling and parent navigation in summary

### DIFF
--- a/doc/neotest.txt
+++ b/doc/neotest.txt
@@ -176,8 +176,11 @@ Default values:
         jumpto = "i",
         mark = "m",
         next_failed = "J",
+        next_sibling = ">",
         output = "o",
+        parent = "P",
         prev_failed = "K",
+        prev_sibling = "<",
         run = "r",
         run_marked = "R",
         short = "O",
@@ -324,6 +327,9 @@ for its adapter
 adapter
 {next_failed} `(string|string[])` Jump to the next failed position
 {prev_failed} `(string|string[])` Jump to the previous failed position
+{next_sibling} `(string|string[])` Jump to the next sibling of selected
+{prev_sibling} `(string|string[])` Jump to the previous sibling of selected
+{parent} `(string|string[])` Jump to the parent of selected
 {watch} `(string|string[])` Toggle watching for changes
 
                                                          *neotest.Config.output*

--- a/lua/neotest/config/init.lua
+++ b/lua/neotest/config/init.lua
@@ -119,6 +119,9 @@ local js_watch_query = [[
 ---@field clear_target string|string[] Clear the target position for the selected adapter
 ---@field next_failed string|string[] Jump to the next failed position
 ---@field prev_failed string|string[] Jump to the previous failed position
+---@field next_sibling string|string[] Jump to the next sibling of selected
+---@field prev_sibling string|string[] Jump to the previous sibling of selected
+---@field parent string|string[] Jump to the parent of selected
 ---@field watch string|string[] Toggle watching for changes
 
 ---@class neotest.Config.output
@@ -239,6 +242,9 @@ local default_config = {
     mappings = {
       expand = { "<CR>", "<2-LeftMouse>" },
       expand_all = "e",
+      parent = "P",
+      prev_sibling = "<",
+      next_sibling = ">",
       output = "o",
       short = "O",
       attach = "a",


### PR DESCRIPTION
This provides three mappings in the summary consumer:

- `prev_sibling` to move the cursor to the previous sibling at the current indent level in the tree
- `next_sibling` to move the cursor to the next sibling at the current indent level in the tree
- `parent` to move the cursor to the parent of the currently selected node

By default, these are bound respectively to `<`, `>`, and `P`, matching the default bindings in nvim-tree.

I didn't notice any contribution guidelines so I just generally tried to make reasonable choices; happy to make adjustments if you'd like.