### PR TITLE
fix(subprocess): Ensure plugin/filetypes.lua loaded after modifying runtimepath

### DIFF
--- a/lua/neotest/lib/subprocess.lua
+++ b/lua/neotest/lib/subprocess.lua
@@ -116,6 +116,7 @@ function neotest.lib.subprocess.add_to_rtp(to_add)
   end
   logger.debug("Setting rtp in subprocess", rtp)
   nio.fn.rpcrequest(child_chan, "nvim_set_option_value", "runtimepath", rtp, {})
+  nio.fn.rpcrequest(child_chan, "nvim_exec_lua", "vim.cmd('runtime! plugin/filetypes.lua')", {})
 end
 
 ---@private


### PR DESCRIPTION
nvim-treesitter's `main` branch behaves differently than the `master` branch did when it comes to mapping filetypes to parsers. In `main` those mappings have been moved to [`plugin/filetypes.lua`](https://github.com/nvim-treesitter/nvim-treesitter/blob/main/plugin/filetypes.lua). Neovim automatically sources files from `plugin/` directories found in `runtimepath` during startup initialization.

However, when neotest's subprocess starts neovim with `-u NONE` nvim-treesitter is not yet in `runtimepath` so the file is never detected. This can lead to unexpected (and often confusing) `No parser for language "..."` errors in the neotest log. To the user this often manifests as a nearly empty `:Neotest summary` window.

https://github.com/nvim-neotest/neotest/blob/2cf3544fb55cdd428a9a1b7154aea9c9823426e8/lua/neotest/lib/subprocess.lua#L42-L50

Neotest eventually adds nvim-treesitter and the other necessary plugins to the subprocess's `runtimepath`, but at that point the subprocess Neovim has already performed startup initialization and we've missed the window for the `plugin/` files to be automatically sourced.

https://github.com/nvim-neotest/neotest/blob/2cf3544fb55cdd428a9a1b7154aea9c9823426e8/lua/neotest/lib/subprocess.lua#L62-L72

To solve that problem, this change performs a `:runtime! plugin/filetypes.lua` in the child process any time the `runtimepath` is modified by `add_to_rtp`, achieving two things:
1. It ensures that nvim-treesitter's filetypes.lua gets loaded before any adapter is executed, so that filetype to parser mappings will be present when the adapter's `discover_positions` function is called. This will solve some of the symptoms reported in #531 (such as `No parser for language "..."` when the filetype is included in nvim-treesitter's mappings) 
2. It gives adapter plugin authors a mechanism to provide additional mappings by including their own `plugin/filetypes.lua`.

It does **NOT**, however, give users any mechanism to ensure that their custom mappings registered via calls to `vim.treesitter.language.register(...)` will be present in the subprocess.

Fortunately, this change is effectively a no-op in cases where there are no `plugin/filetypes.lua` files in any of the plugins on the subprocess's `runtimepath` (such as is the case when using nvim-treesitter's `master` branch).