### PR TITLE
Normalise source path separators when setting up subprocess runtimepath

### DIFF
--- a/lua/neotest/lib/subprocess.lua
+++ b/lua/neotest/lib/subprocess.lua
@@ -104,7 +104,8 @@ function neotest.lib.subprocess.add_to_rtp(to_add)
   local rtp = nio.fn.rpcrequest(child_chan, "nvim_get_option_value", "runtimepath", {})
 
   for _, func in ipairs(to_add) do
-    local source = Path:new(debug.getinfo(func).source:sub(2))
+    local source_path_str = debug.getinfo(func).source:sub(2):gsub("[/\\]", Path.path.sep)
+    local source = Path:new(source_path_str)
     while
       not is_root(source.filename) and not vim.endswith(source.filename, Path.path.sep .. "lua")
     do


### PR DESCRIPTION
This PR fixes an issue where the subprocess fails to start on windows.

On windows, the subprocess fails to start with:

```
DEBUG | 2025-10-30T19:42:45Z+0000 | ...al/nvim-data/lazy/neotest/lua/neotest/lib/subprocess.lua:118 | Setting rtp in subprocess C:\Users\cotta\AppData\Local\nvim,C:\Users\cotta\AppData\Local\nvim-data\site,C:\Users\cotta\scoop\apps\neovim\current\share/nvim/runtime,C:\Users\cotta\scoop\apps\neovim\current\lib/nvim,C:\Users\cotta\AppData\Local\nvim-data\site\after,C:\Users\cotta\AppData\Local\nvim\after
ERROR | 2025-10-30T19:42:45Z+0000 | ...al/nvim-data/lazy/neotest/lua/neotest/lib/subprocess.lua:90 | Failed to initialize child process Vim:Error invoking 'nvim_exec_lua' on channel 3:
Error executing lua: [string "<nvim>"]:1: module 'neotest' not found:
	no field package.preload['neotest']
	no file '.\neotest.lua'
	no file 'C:\Users\cotta\scoop\apps\neovim\current\bin\lua\neotest.lua'
	no file 'C:\Users\cotta\scoop\apps\neovim\current\bin\lua\neotest\init.lua'
	no file '.\neotest.dll'
	no file 'C:\Users\cotta\scoop\apps\neovim\current\bin\neotest.dll'
	no file 'C:\Users\cotta\scoop\apps\neovim\current\bin\loadall.dll'
stack traceback:
	[C]: in function 'require'
	[string "<nvim>"]:1: in main chunk
stack traceback:
	[C]: in function 'rpcrequest'
	...al/nvim-data/lazy/neotest/lua/neotest/lib/subprocess.lua:75: in function <...al/nvim-data/lazy/neotest/lua/neotest/lib/subprocess.lua:55>
	[C]: in function 'xpcall'
	...al/nvim-data/lazy/neotest/lua/neotest/lib/subprocess.lua:55: in function 'init'
	...Local/nvim-data/lazy/neotest/lua/neotest/client/init.lua:372: in function '_start'
	...Local/nvim-data/lazy/neotest/lua/neotest/client/init.lua:186: in function '_ensure_started'
	...Local/nvim-data/lazy/neotest/lua/neotest/client/init.lua:171: in function 'get_adapters'
	...a/lazy/neotest/lua/neotest/consumers/summary/summary.lua:155: in function <...a/lazy/neotest/lua/neotest/consumers/summary/summary.lua:154>
```

The runtimepath passed to the subprocess is missing neotest and it's dependencies.

Further testing reveals that, in ```neotest.lib.subprocess.add_to_rtp```, the path to the source file returned from ```debug.getinfo``` has forward-slashes, which aren't seen as separators on windows by plenary's path class. This prevents the function from iterating up the source file's ancestors to find the root of the module. 

Normalising the separators to back-slashes before creating the path resolves the issue. This PR normalises any separators to the correct separators for the current platform.