### PR TITLE
Allow hidden directories to be searched for tests

### DIFF
--- a/lua/neotest/lib/file/find.lua
+++ b/lua/neotest/lib/file/find.lua
@@ -51,7 +51,7 @@ function M.find(root, opts)
       local rel_path = name and (dir == "" and name or (dir .. sep .. name))
       if
         path_type == "directory"
-        and name:sub(1, 1) ~= "."
+        and (name:sub(1, 1) ~= "." and not opts.filter_dir.include_hidden)
         and (not filter_dir or filter_dir(name, rel_path, root))
       then
         dirs_to_scan[#dirs_to_scan + 1] = rel_path

--- a/lua/neotest/lib/file/find.lua
+++ b/lua/neotest/lib/file/find.lua
@@ -51,7 +51,7 @@ function M.find(root, opts)
       local rel_path = name and (dir == "" and name or (dir .. sep .. name))
       if
         path_type == "directory"
-        and (name:sub(1, 1) ~= "." and not opts.filter_dir.include_hidden)
+        and (name:sub(1, 1) ~= "." or opts.include_hidden)
         and (not filter_dir or filter_dir(name, rel_path, root))
       then
         dirs_to_scan[#dirs_to_scan + 1] = rel_path


### PR DESCRIPTION
Hi,

I have tests within the `.github` directory to provide tests for GitHub Actions. I could not find a way to include this directory without some modifications to `find.lua`. If there is another way, please do let me know.

I have added the option `include_hidden`. I am also open to renaming to whatever makes sense.