### PR TITLE
fix(dap): provide a safe context for dap initialization

### DIFF
--- a/lua/neotest/client/strategies/dap/init.lua
+++ b/lua/neotest/client/strategies/dap/init.lua
@@ -28,6 +28,8 @@ return function(spec, context)
   if vim.tbl_isempty(spec.strategy) then
     return
   end
+  -- synchronize with main loop to safely require dap
+  nio.scheduler()
   local dap = require("dap")
 
   local handler_id = "neotest_" .. nio.fn.localtime()


### PR DESCRIPTION
I am using LazyVim.

I have been investigating a breakage with some adapters ([neotest-jest](https://github.com/neotest/neotest-jest) and [neotest-vitest](https://github.com/marilari88/neotest-vitest)), where starting a debug session from a test from inside the neotest summary window results in dap failing to initialize if it wasn't already loaded. If dap was already loaded in the session, debugging the test will work as expected.

Here is a recording of a debug session failing to start when dap is required by neotest and wasn't loaded beforehand:

https://github.com/user-attachments/assets/8816ff55-9b20-442f-b33c-a7ba5b55d12d

This is the resulting stack trace:
<pre>
neotest-vitest: ...s/aitor/.local/share/nvim/lazy/nvim-nio/lua/nio/init.lua:119: The coroutine failed with this message:
...itor/.local/share/nvim/lazy/nvim-nio/lua/nio/control.lua:293: vim/keymap.lua:0: E5560: nvim_set_keymap must not be called in a fast event context
stack traceback:
	[C]: in function 'error'
	...itor/.local/share/nvim/lazy/nvim-nio/lua/nio/control.lua:293: in function 'with'
	...nvim/lazy/neotest/lua/neotest/client/strategies/init.lua:39: in function 'run'
	...al/share/nvim/lazy/neotest/lua/neotest/client/runner.lua:130: in function '_run_spec'
	...al/share/nvim/lazy/neotest/lua/neotest/client/runner.lua:89: in function <...al/share/nvim/lazy/neotest/lua/neotest/client/runner.lua:88>
stack traceback:
	...ocal/share/nvim/lazy/neotest/lua/neotest/client/init.lua:89: in function <...ocal/share/nvim/lazy/neotest/lua/neotest/client/init.lua:88>
	[C]: in function 'error'
	...s/aitor/.local/share/nvim/lazy/nvim-nio/lua/nio/init.lua:119: in function 'gather'
	...al/share/nvim/lazy/neotest/lua/neotest/client/runner.lua:94: in function '_run_tree'
	...al/share/nvim/lazy/neotest/lua/neotest/client/runner.lua:65: in function <...al/share/nvim/lazy/neotest/lua/neotest/client/runner.lua:22>
	[C]: in function 'xpcall'
	...ocal/share/nvim/lazy/neotest/lua/neotest/client/init.lua:84: in function 'run_tree'
	...al/share/nvim/lazy/neotest/lua/neotest/consumers/run.lua:85: in function 'func'
	.../aitor/.local/share/nvim/lazy/nvim-nio/lua/nio/tasks.lua:169: in function <.../aitor/.local/share/nvim/lazy/nvim-nio/lua/nio/tasks.lua:168>
</pre>


Here is a recording of a debug session working as expected because dap was loaded beforehand (by adding a breakpoint):

https://github.com/user-attachments/assets/27b6b52d-a294-41a6-b28a-85e18f8a2610

After some investigation, the reason is both neotest-jest's and neotest-vitest's `adapter.build_spec`s are starting a write operation before returning the control to neotest (example:
https://github.com/nvim-neotest/neotest-jest/blob/a36df9109c75bd1ae46b7bad274615dbbe6e4dcd/lua/neotest-jest/init.lua#L488-L492).
This results in neotest requiring dap while in a fast event context, which results in dap failing to initialize.

This PR solves the issue by forcing a nio synchronization before requiring dap. Result:

https://github.com/user-attachments/assets/44a6dc01-fa47-4e7c-a74e-d29651c13f23