### PR TITLE
fix(subprocess): remove hard dependency on nvim-treesitter

### DIFF
--- a/lua/neotest/lib/subprocess.lua
+++ b/lua/neotest/lib/subprocess.lua
@@ -63,9 +63,9 @@ function neotest.lib.subprocess.init()
       require("neotest").setup,
       require("nio").sleep,
       require("plenary.path").new,
-      require("nvim-treesitter").new,
     }
     if pcall(require, "nvim-treesitter") then
+      to_add[#to_add + 1] = require("nvim-treesitter").new
       to_add[#to_add + 1] = require("nvim-treesitter").setup
     end
 


### PR DESCRIPTION
`require("nvim-treesitter") fails if nvim-treesitter is not installed. Since nvim-treesitter `main` doesn't provide a Lua API, it shouldn't be a hard dependency.