### PR TITLE
fix(lib): vim.notify takes level as an integer

### DIFF
--- a/lua/neotest/client/init.lua
+++ b/lua/neotest/client/init.lua
@@ -90,7 +90,7 @@ function neotest.Client:run_tree(tree, args)
   end)
 
   if not success then
-    lib.notify(("%s: %s"):format(adapter.name, errmsg), "warn")
+    lib.notify(("%s: %s"):format(adapter.name, errmsg), vim.log.levels.WARN)
     all_results = {}
     for _, pos in tree:iter() do
       all_results[pos.id] = { status = "skipped" }
@@ -115,7 +115,7 @@ function neotest.Client:stop(position, args)
   args = args or {}
   local adapter_id = args.adapter or self:_get_running_adapters(position:data().id)[1]
   if not adapter_id then
-    lib.notify("No running process found", "warn")
+    lib.notify("No running process found", vim.log.levels.WARN)
     return
   end
   self._runner:stop(position, adapter_id)
@@ -132,7 +132,7 @@ function neotest.Client:attach(position, args)
   args = args or {}
   local adapter_id = args.adapter or self:_get_running_adapters(position:data().id)[1]
   if not adapter_id then
-    lib.notify("No running process found", "warn")
+    lib.notify("No running process found", vim.log.levels.WARN)
     return
   end
   self._runner:attach(position, adapter_id)

--- a/lua/neotest/consumers/output.lua
+++ b/lua/neotest/consumers/output.lua
@@ -8,7 +8,7 @@ local function open_output(result, opts)
   local output = opts.short and result.short or (result.output and lib.files.read(result.output))
   if not output then
     if not opts.quiet then
-      lib.notify("Output not found for position", "warn")
+      lib.notify("Output not found for position", vim.log.levels.WARN)
     end
     return
   end
@@ -179,7 +179,7 @@ function neotest.output.open(opts)
     tree, adapter_id = client:get_position(opts.position_id, opts)
   end
   if not tree then
-    lib.notify("No tests found in file", "warn")
+    lib.notify("No tests found in file", vim.log.levels.WARN)
     return
   end
   local result = client:get_results(adapter_id)[tree:data().id]

--- a/lua/neotest/consumers/run.lua
+++ b/lua/neotest/consumers/run.lua
@@ -154,7 +154,7 @@ function neotest.run.stop(args)
     pos = neotest.run.get_tree_from_args(args)
   end
   if not pos then
-    lib.notify(args.interactive and "No test selected" or "No tests found", "warn")
+    lib.notify(args.interactive and "No test selected" or "No tests found", vim.log.levels.WARN)
     return
   end
   client:stop(pos, args)
@@ -181,7 +181,7 @@ function neotest.run.attach(args)
     pos = neotest.run.get_tree_from_args(args)
   end
   if not pos then
-    lib.notify(args.interactive and "No test selected" or "No tests found", "warn")
+    lib.notify(args.interactive and "No test selected" or "No tests found", vim.log.levels.WARN)
     return
   end
   client:attach(pos, args)


### PR DESCRIPTION
From `:h vim.notify`:

    vim.notify({msg}, {level}, {opts})                              *vim.notify()*
        ...
        Parameters: ~
          • {msg}    (`string`) Content of the notification to show to the user.
          • {level}  (`integer?`) One of the values from |vim.log.levels|.
          • {opts}   (`table?`) Optional parameters. Unused by default.

I hit this after switching to mini.notify, which doesn't handle level as a string. Seeing as vim.notify's api docs state that it should be an int, I think it would be safe to assume that notification plugins that support other types are an extension and not part of the core