### PR TITLE
fix(utils): use vim.fn.has instead of nio.fn.has in tbl_flatten

### DIFF
--- a/lua/neotest/utils/init.lua
+++ b/lua/neotest/utils/init.lua
@@ -1,9 +1,7 @@
-local nio = require("nio")
-
 local M = {}
 
 function M.tbl_flatten(t)
-  return nio.fn.has("nvim-0.11") == 1 and vim.iter(t):flatten(math.huge):totable()
+  return vim.fn.has("nvim-0.11") == 1 and vim.iter(t):flatten(math.huge):totable()
     or vim.tbl_flatten(t)
 end
 


### PR DESCRIPTION
## Problem

`utils.tbl_flatten` uses `nio.fn.has("nvim-0.11")` which is async. This causes a **"attempt to yield across C-call boundary"** error when called from the neotest subprocess context.

The failure path:
1. Neotest spawns a subprocess for treesitter test discovery
2. Subprocess executes `require('neotest-go')` (to resolve `position_id`)
3. `neotest-go/init.lua` calls `lib.files.match_root_pattern("go.mod", "go.sum")` at module load time
4. `match_root_pattern` calls `utils.tbl_flatten({...})`
5. `utils.tbl_flatten` calls `nio.fn.has("nvim-0.11")` → tries to yield → **error**

The subprocess reports the error but — critically — `parse_positions` does not `pcall` around `lib.subprocess.call`, so the error is **raised** rather than returned. This means the `if err then` branch is never reached, `child_failed` is never set to `true`, and every subsequent parse attempt also goes through the subprocess and fails the same way.

**Result**: `discover_positions` never returns a valid tree → neotest reports **"No tests found"** for all tests.

## Fix

Replace `nio.fn.has` with `vim.fn.has`. Both call the same underlying vimscript `has()` function; `vim.fn.has` is synchronous and works correctly in all contexts including the subprocess.

## Reproduction

Open a Go project with a `go.mod` and a `*_test.go` file, then run `:lua require("neotest").run.run()`. Check `~/.local/state/nvim/neotest.log` for repeated `"attempt to yield across C-call boundary"` errors from the child process.