### PR TITLE
fix: ignore window-scoped DirChanged autocmds

### DIFF
--- a/lua/neotest/client/init.lua
+++ b/lua/neotest/client/init.lua
@@ -459,8 +459,11 @@ function neotest.Client:_start(args)
     end)
   end)
 
-  autocmd("DirChanged", function()
-    local dir = vim.loop.cwd()
+  autocmd("DirChanged", function(args)
+    if vim.v.event.scope == "window" then
+      return
+    end
+    local dir = vim.v.event.cwd or vim.loop.cwd()
     nio.run(function()
       self:_update_adapters(dir)
     end)


### PR DESCRIPTION
some plugins can modify their local dir using `:lcd`. For example Neogit finds the Git root and then sets it as local base dir. This should however not affect Neotest imo. When I am working in a monorepo I often intentionally open up a subdirectory (e.g. ./backend) because I only want to work on this specific part of the code base.

Then after opening Neogit, when I come back to neotest summary I suddenly see all other parts of the monorepo which I am not interested in. This PR changes it so that we ignore window-scoped `DirChanged` events and only act on global or tab-scope. the latter is somewhat debatable too but I wanted to keep my changes non-invasive

fix #327