### PR TITLE
fix(summary): add missing keymaps to run target position

### DIFF
--- a/lua/neotest/consumers/summary/component.lua
+++ b/lua/neotest/consumers/summary/component.lua
@@ -48,6 +48,16 @@ function SummaryComponent:render(canvas, tree, expanded, focused, indent)
     if not tree then
       return
     end
+    local position = tree:data()
+    canvas:add_mapping("run", function()
+      require("neotest").run.run({ position.id, adapter = self.adapter_id })
+    end)
+    canvas:add_mapping("debug", function()
+      require("neotest").run.run({ position.id, adapter = self.adapter_id, strategy = "dap" })
+    end)
+    canvas:add_mapping("stop", function()
+      require("neotest").run.stop({ position.id, adapter = self.adapter_id })
+    end)
     canvas:add_mapping("clear_target", function()
       require("neotest").summary.target(self.adapter_id)
     end)


### PR DESCRIPTION
when a target (e.g. a test class or test file) is selected in the summary view there was no direct way to run all contained tests. since those mappings also exist for test files I added the same ones for consistency