### PR TITLE
fix: iter_matches breaking change

### DIFF
--- a/lua/neotest/config/init.lua
+++ b/lua/neotest/config/init.lua
@@ -340,8 +340,9 @@ local default_config = {
           ]]
         )
         local symbols = {}
-        for _, match, metadata in query:iter_matches(root, content, nil, nil, { all = false }) do
-          for id, node in pairs(match) do
+        for _, match, metadata in query:iter_matches(root, content, nil, nil) do
+          for id, nodes in pairs(match) do
+            local node = type(nodes) == "table" and nodes[#nodes] or nodes
             local name = query.captures[id]
 
             if name == "symbol" then

--- a/lua/neotest/lib/treesitter/init.lua
+++ b/lua/neotest/lib/treesitter/init.lua
@@ -56,15 +56,13 @@ local function collect(file_path, query, source, root, opts)
       range = { root:range() },
     },
   }
-  for _, match, metadata in query:iter_matches(root, source, nil, nil, { all = false }) do
+  for _, match, metadata in query:iter_matches(root, source, nil, nil) do
     local captured_nodes = {}
     local node_metadata = {}
-    for id, nodes in pairs(match) do
-      local capture = query.captures[id]
-      for _, node in ipairs(nodes) do
-        captured_nodes[capture] = node
-        node_metadata[capture] = metadata[id]
-      end
+    for i, capture in ipairs(query.captures) do
+      local maybe_node = match[i]
+      captured_nodes[capture] = type(maybe_node) == "table" and maybe_node[#maybe_node] or maybe_node
+      node_metadata[capture] = metadata[i]
     end
     local res = opts.build_position(file_path, source, captured_nodes, node_metadata)
     if res then


### PR DESCRIPTION
Resolves #590

This issue is caused by the removal of the `all` option in `Query:iter_matches` (neovim/neovim@a728eb7).

This change updates neotest to handle the new API shape, where captures may be returned as multiple nodes, instead of relying on `{ all = false }`. When multiple nodes are returned, the last node is selected to preserve the previous behavior.

- Verified the fix on Neovim 0.12+
- Confirmed backward compatibility with 0.11.6
- Re-enabled and ran `tests/unit/lib/treesitter/init_spec_disabled.lua` locally

Let me know if you'd prefer a different approach. I'm new to the project and Lua, so happy to adjust.