### PR TITLE
feat: Allow overlapping ranges when searching for nearest position

### DIFF
--- a/doc/neotest.txt
+++ b/doc/neotest.txt
@@ -1618,7 +1618,10 @@ Fields~
 {type} `(neotest.PositionType)`
 {name} `(string)`
 {path} `(string)`
-{range} `(integer[])`
+{range} `(integer[])` range of test definition
+{total_range} `(integer[])` minimum range encapsulating the test and all its
+subtests (in some languages, a test can have subtests outside of its
+definition)
 
                                                                 *M.ResultStatus*
 `ResultStatus`

--- a/lua/neotest/client/init.lua
+++ b/lua/neotest/client/init.lua
@@ -151,16 +151,7 @@ function neotest.Client:get_nearest(file_path, row, args)
   if not positions then
     return
   end
-  local nearest
-  for _, node in positions:iter_nodes() do
-    node = node:closest_node_with("range") or node
-    local range = node:data().range
-    if range and range[1] <= row then
-      nearest = node
-    else
-      return nearest, adapter_id
-    end
-  end
+  local nearest = lib.positions.nearest(positions, row)
   return nearest, adapter_id
 end
 

--- a/lua/neotest/lib/file/init.lua
+++ b/lua/neotest/lib/file/init.lua
@@ -293,6 +293,7 @@ function neotest.lib.files.parse_dir_from_files(root, files)
         path = abs_path,
         name = path_elems[#path_elems],
         range = nil,
+        total_range = nil,
       }
     end
     return positions

--- a/lua/neotest/lib/positions/init.lua
+++ b/lua/neotest/lib/positions/init.lua
@@ -49,7 +49,7 @@ neotest.lib.positions.nearest = function(tree, line)
   for _, node in tree:iter_nodes({continue = continue}) do
     local pos = node:closest_node_with("range"):data()
     local range = pos.total_range or pos.range
-    if range then
+    if node:data().type ~= "file" and range then
       local dist = distance(line, range)
       local size = range_size(range)
       if nearest_distance == nil or dist < nearest_distance or

--- a/lua/neotest/lib/positions/init.lua
+++ b/lua/neotest/lib/positions/init.lua
@@ -47,18 +47,35 @@ neotest.lib.positions.nearest = function(tree, line)
   local nearest_distance = nil
   local nearest_range_size = nil
   for _, node in tree:iter_nodes({continue = continue}) do
-    local pos = node:closest_node_with("range"):data()
-    local range = pos.total_range or pos.range
-    if node:data().type ~= "file" and range then
+    (function()
+      if node:data().type == "file" then
+        -- In the first iteration of iter_nodes, node will be the root node,
+        -- which is already selected by default. We do not want to set
+        -- nearest_distance to 0 for it as it will break the logic when
+        -- given line is between tests.
+        return
+      end
+      local pos = node:closest_node_with("range"):data()
+      local range = pos.total_range or pos.range
+      if not range then
+        -- Skip tests without ranges
+        return
+      end
+      if line < range[1] then
+        -- Ignore ranges that start after the given line
+        -- Nearest test should always be at or before given line
+        return
+      end
       local dist = distance(line, range)
       local size = range_size(range)
-      if nearest_distance == nil or dist < nearest_distance or
+      if nearest_distance == nil or
+          dist < nearest_distance or
           (dist == nearest_distance and size < nearest_range_size) then
         nearest = node
         nearest_distance = dist
         nearest_range_size = size
       end
-    end
+    end)()
   end
   return nearest
 end

--- a/lua/neotest/lib/positions/init.lua
+++ b/lua/neotest/lib/positions/init.lua
@@ -10,19 +10,51 @@ local neotest = { lib = {} }
 ---@class neotest.lib.positions
 neotest.lib.positions = {}
 
+--- Calculates distance from given line to given range
+--- @param line integer line number
+--- @param range integer[] range represented as 4 integers: start_row, start_col, end_row, end_col
+--- @return integer Distance from given line to the range. If line is within range, distance is 0.
+local function distance(line, range)
+    local start_row, end_row = range[1], range[3]
+    if line < start_row then
+        return start_row - line
+    elseif line <= end_row then
+        return 0
+    else
+        return line - end_row
+    end
+end
+
+--- Calculates number of lines of given range
+--- @param range integer[] range represented as 4 integers: start_row, start_col, end_row, end_col
+--- @return integer Number of lines that the range spans over
+local function range_size(range)
+    local start_row, end_row = range[1], range[3]
+    return end_row - start_row + 1
+end
+
 --- Get the nearest position to the given line in the provided file tree
 ---@param tree neotest.Tree
 ---@param line integer
 ---@return neotest.Tree
 neotest.lib.positions.nearest = function(tree, line)
+  local continue = function(node)
+    local range = node:data().range
+    return not range or line >= range[1]
+  end
   local nearest = tree
-  for _, node in tree:iter_nodes() do
-    local pos = node:data()
-    if pos.range then
-      if line >= pos.range[1] then
+  local nearest_distance = nil
+  local nearest_range_size = nil
+  for _, node in tree:iter_nodes({continue = continue}) do
+    local range = node:closest_value_for("range")
+    if range then
+      local dist = distance(line, range)
+      local size = range_size(range)
+      if nearest_distance == nil or dist < nearest_distance or
+          (dist == nearest_distance and size < nearest_range_size) then
         nearest = node
-      else
-        return nearest
+        nearest_distance = dist
+        nearest_range_size = size
       end
     end
   end

--- a/lua/neotest/lib/positions/init.lua
+++ b/lua/neotest/lib/positions/init.lua
@@ -39,14 +39,16 @@ end
 ---@return neotest.Tree
 neotest.lib.positions.nearest = function(tree, line)
   local continue = function(node)
-    local range = node:data().range
+    local data = node:data()
+    local range = data.total_range or data.range
     return not range or line >= range[1]
   end
   local nearest = tree
   local nearest_distance = nil
   local nearest_range_size = nil
   for _, node in tree:iter_nodes({continue = continue}) do
-    local range = node:closest_value_for("range")
+    local pos = node:closest_node_with("range"):data()
+    local range = pos.total_range or pos.range
     if range then
       local dist = distance(line, range)
       local size = range_size(range)

--- a/lua/neotest/lib/positions/init.lua
+++ b/lua/neotest/lib/positions/init.lua
@@ -15,22 +15,22 @@ neotest.lib.positions = {}
 --- @param range integer[] range represented as 4 integers: start_row, start_col, end_row, end_col
 --- @return integer Distance from given line to the range. If line is within range, distance is 0.
 local function distance(line, range)
-    local start_row, end_row = range[1], range[3]
-    if line < start_row then
-        return start_row - line
-    elseif line <= end_row then
-        return 0
-    else
-        return line - end_row
-    end
+  local start_row, end_row = range[1], range[3]
+  if line < start_row then
+    return start_row - line
+  elseif line <= end_row then
+    return 0
+  else
+    return line - end_row
+  end
 end
 
 --- Calculates number of lines of given range
 --- @param range integer[] range represented as 4 integers: start_row, start_col, end_row, end_col
 --- @return integer Number of lines that the range spans over
 local function range_size(range)
-    local start_row, end_row = range[1], range[3]
-    return end_row - start_row + 1
+  local start_row, end_row = range[1], range[3]
+  return end_row - start_row + 1
 end
 
 --- Get the nearest position to the given line in the provided file tree
@@ -46,7 +46,7 @@ neotest.lib.positions.nearest = function(tree, line)
   local nearest = tree
   local nearest_distance = nil
   local nearest_range_size = nil
-  for _, node in tree:iter_nodes({continue = continue}) do
+  for _, node in tree:iter_nodes({ continue = continue }) do
     (function()
       if node:data().type == "file" then
         -- In the first iteration of iter_nodes, node will be the root node,
@@ -68,9 +68,11 @@ neotest.lib.positions.nearest = function(tree, line)
       end
       local dist = distance(line, range)
       local size = range_size(range)
-      if nearest_distance == nil or
-          dist < nearest_distance or
-          (dist == nearest_distance and size < nearest_range_size) then
+      if
+        nearest_distance == nil
+        or dist < nearest_distance
+        or (dist == nearest_distance and size < nearest_range_size)
+      then
         nearest = node
         nearest_distance = dist
         nearest_range_size = size

--- a/lua/neotest/types/init.lua
+++ b/lua/neotest/types/init.lua
@@ -13,7 +13,10 @@ M.PositionType = {
 ---@field type neotest.PositionType
 ---@field name string
 ---@field path string
----@field range integer[]
+---@field range integer[] range of test definition
+---@field total_range integer[] minimum range encapsulating the test and all its
+--- subtests (in some languages, a test can have subtests outside of its
+--- definition)
 
 ---@enum neotest.ResultStatus
 M.ResultStatus = {


### PR DESCRIPTION
Problem
===
I want to improve the support of testify suites in the neotest-golang adapter.
In golang, [testify suites](https://pkg.go.dev/github.com/stretchr/testify/suite) is a popular way of writing tests. The main
idea is that you create a suite struct, and methods of the struct become tests. Example:
```go
type ExampleTestSuite struct {
	suite.Suite
}

func (suite *ExampleTestSuite) TestExample() {
	suite.Equal(5, 5)
}

func (suite *ExampleTestSuite) TestExample2() {
	suite.Equal(5, 5)
}

func TestExampleTestSuite(t *testing.T) {
    suite.Run(t, new(ExampleTestSuite))
}
```

The most natural way of representing this suite as a neotest tree is like so:
```
 ╰╮  TestExampleTestSuite
  ├─  TestExample
  ╰─  TestExample2
```

The problem is that the language allows for testify suites to interleave with each other. Example:
```go
type ExampleTestSuite struct {
	suite.Suite
}

func (suite *ExampleTestSuite) TestExample() {
	suite.Equal(5, 5)
}

type ExampleTestSuite2 struct {
	suite.Suite
}

func (suite *ExampleTestSuite2) TestExample3() {
	suite.Equal(5, 5)
}

func TestExampleTestSuite2(t *testing.T) {
    suite.Run(t, new(ExampleTestSuite2))
}

func (suite *ExampleTestSuite) TestExample2() { // method from the first test suite
	suite.Equal(5, 5)
}

func TestExampleTestSuite(t *testing.T) {
    suite.Run(t, new(ExampleTestSuite))
}
```

Solution
===
My idea is to introduce a new `total_range` field in the `neotest.Position` type and to
allow the neotest tree to have nodes with overlapping ranges. Example:

```
├╮  TestExampleTestSuite  {range: line 25-27, total_range: line 5-27}
│├─  TestExample          {range: line 5-7, total_range: line 5-7}
│╰─  TestExample2         {range: line 21-23, total_range: line 21-23}
╰╮  TestExampleTestSuite2 {range: line 17-19, total_range: line 13-19}
 ╰─  TestExample3         {range: line 13-15, total_range: line 13-15}
```

Having that, the nearest test algorithm is modified **not** to stop at the first encounter of a test
whose range starts after the given line, but to cutoff that branch of the tree and keep exploring other
branches. The assumptions of the algorithm are:

 * the node's `range` will be used as the node's `total_range` if the `total_range` is not specified
 * the `range` and `total_range` of every child of a node is strictly within the node's `total_range`
 * children of a node are sorted by the start of their `total_range`