### PR TITLE
style(summary): add icons for dirs, files and namespaces

### DIFF
--- a/lua/neotest/config/init.lua
+++ b/lua/neotest/config/init.lua
@@ -34,7 +34,7 @@ local js_watch_query = [[
   ;Captures default import
   (import_clause (identifier) @symbol)
   ;Capture require statements
-  (variable_declarator 
+  (variable_declarator
   name: (identifier) @symbol
   value: (call_expression (identifier) @function  (#eq? @function "require")))
   ;Capture namespace imports
@@ -198,6 +198,9 @@ local default_config = {
     watching = "",
     test = "",
     notify = "",
+    dir = "",
+    file = "",
+    namespace = "",
   },
   highlights = {
     passed = "NeotestPassed",

--- a/lua/neotest/consumers/summary/component.lua
+++ b/lua/neotest/consumers/summary/component.lua
@@ -342,7 +342,7 @@ function SummaryComponent:_get_status(position)
   elseif self.client:is_running(position.id, { adapter = self.adapter_id }) then
     return "running"
   end
-  return "unknown"
+  return position.type
 end
 
 function SummaryComponent:_state_icon(status)


### PR DESCRIPTION
Instead of using an unknown icon in the summary use the icon for the position type.

This makes it clearer what the positions represent and looks nicer (imo).