### PR TITLE
fix(client/init) : use adapter root as path for rtp

### DIFF
--- a/lua/neotest/client/init.lua
+++ b/lua/neotest/client/init.lua
@@ -570,7 +570,7 @@ function neotest.Client:_update_adapters(dir)
 
   local to_add = {}
   for _, entry in pairs(new_adapters) do
-    to_add[#to_add + 1] = entry.adapter.is_test_file
+    to_add[#to_add + 1] = entry.root
   end
   if #to_add > 0 and lib.subprocess.enabled() then
     local suc, err = pcall(lib.subprocess.add_paths_to_rtp, to_add)


### PR DESCRIPTION
## Description

When I open the test summary on my project, I get the following error

```
ERROR | {date} | ...ocal/share/nvim/lazy/neotest/lua/neotest/client/init.lua:578 | Failed to add adapter to rtp ...l/share/nvim/lazy/neotest/lua/neotest/lib/subprocess.lua:173: attempt to concatenate local 'path' (a function value)
```

### Changes

I inspired from the other uses of `add_paths_to_rtp`, e.g. [here](https://github.com/nvim-neotest/neotest/blob/ad991822b7076b1d940b33a9d6d0d30416d5df81/lua/neotest/lib/subprocess.lua#L71) where the adapter root is used

- use the adapter root as path instead of the function `adapter.is_test_file`

### Notes

Tested on Neovim 0.12.1