### PR TITLE
docs(README): add Tryke adapter (Python)

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ See the adapter's documentation for their specific setup instructions.
 | :-------------------- | :-------------------------------------------------------------------------------------------------------------------------: |
 | pytest                |                              [neotest-python](https://github.com/nvim-neotest/neotest-python)                               |
 | python-unittest       |                              [neotest-python](https://github.com/nvim-neotest/neotest-python)                               |
+| python (tryke) |                              [neotest-tryke](https://github.com/thejchap/neotest-tryke) |
 | plenary               |                             [neotest-plenary](https://github.com/nvim-neotest/neotest-plenary)                              |
 | go                    | [neotest-go](https://github.com/akinsho/neotest-go) <br> [neotest-golang](https://github.com/fredrikaverpil/neotest-golang) |
 | jest                  |                                 [neotest-jest](https://github.com/haydenmeade/neotest-jest)                                 |


### PR DESCRIPTION
Updates `README.md` to add [neotest-tryke](https://github.com/thejchap/neotest-tryke), a new adapter for the [Tryke](https://github.com/thejchap/tryke) test framework for Python