### PR TITLE
fix(windows): resolve drive casing mismatch, watch consumer failures and subprocess crashes

### DIFF
--- a/lua/neotest/client/init.lua
+++ b/lua/neotest/client/init.lua
@@ -188,6 +188,7 @@ end
 function neotest.Client:get_position(position_id, args)
   self:_ensure_started()
   args = args or {}
+  position_id = lib.files.path.normalize(position_id)
   if position_id and vim.endswith(position_id, lib.files.sep) then
     position_id = string.sub(position_id, 1, #position_id - #lib.files.sep)
   end
@@ -243,6 +244,7 @@ end
 ---@param path string
 ---@private
 function neotest.Client:_update_positions(path, args)
+  path = lib.files.path.normalize(path)
   if not lib.files.exists(path) then
     return
   end

--- a/lua/neotest/consumers/watch/init.lua
+++ b/lua/neotest/consumers/watch/init.lua
@@ -66,6 +66,7 @@ end
 local function get_lsp_client(tree)
   for _, buf in ipairs(nio.api.nvim_list_bufs()) do
     local path = nio.fn.fnamemodify(nio.api.nvim_buf_get_name(buf), ":p")
+    path = lib.files.path.normalize(path)
     if tree:get_key(path) then
       local client = get_valid_client(buf)
       if client then

--- a/lua/neotest/consumers/watch/watcher.lua
+++ b/lua/neotest/consumers/watch/watcher.lua
@@ -3,6 +3,8 @@ local logger = require("neotest.logging")
 local nio = require("nio")
 local config = require("neotest.config")
 
+
+
 ---@class neotest.consumers.watch.Watcher
 ---@field lsp_client nio.lsp.Client
 ---@field autocmd_id? string
@@ -71,9 +73,9 @@ function Watcher:_get_linked_files(path, root_path, args)
       end
     end
   end
-  local paths = { path }
+  local paths = { lib.files.path.normalize(path) }
   for uri in pairs(dependency_uris) do
-    local p = vim.uri_to_fname(uri)
+    local p = lib.files.path.normalize(vim.uri_to_fname(uri))
     if uri ~= path_uri and args.filter_path(p, root_path) then
       paths[#paths + 1] = p
     end
@@ -171,13 +173,14 @@ function Watcher:watch(tree, args)
       end
       nio.run(function()
         local path = nio.fn.expand(nio.api.nvim_buf_get_name(autocmd_args.buf), ":p")
+        path = lib.files.path.normalize(path)
 
         local buf_dependants = dependants[path]
         if not buf_dependants then
           return
         end
 
-        if path == tree:data().path then
+        if path == lib.files.path.normalize(tree:data().path) then
           self.discover_positions_event.wait()
         end
         self.discover_positions_event = nio.control.future()

--- a/lua/neotest/lib/file/init.lua
+++ b/lua/neotest/lib/file/init.lua
@@ -230,8 +230,19 @@ end)()
 neotest.lib.files.path = {
   sep = neotest.lib.files.sep,
   exists = neotest.lib.files.exists,
+  normalize = function(path)
+    if type(path) == "string" and vim.fn.has("win32") == 1 then
+      local drive, rest = path:match("^([a-zA-Z]:)(.*)$")
+      if drive then
+        path = drive:upper() .. rest
+      end
+      path = path:gsub("/", "\\")
+    end
+    return path
+  end,
   real = function(path)
     local normalized_path = nio.fn.fnamemodify(path, ":p")
+    normalized_path = neotest.lib.files.path.normalize(normalized_path)
     local exists = neotest.lib.files.exists(normalized_path)
     return exists and normalized_path or nil, exists
   end,

--- a/lua/neotest/lib/subprocess.lua
+++ b/lua/neotest/lib/subprocess.lua
@@ -66,6 +66,10 @@ function neotest.lib.subprocess.init()
       require("nio").sleep,
       require("plenary.path").new,
     }
+    local has_ts, ts = pcall(require, "nvim-treesitter")
+    if has_ts and ts.setup then
+      table.insert(plugin_funcs, ts.setup)
+    end
 
     for _, plugin_func in ipairs(plugin_funcs) do
       local root = neotest.lib.subprocess.resolve_plugin_root(plugin_func)
@@ -166,7 +170,17 @@ end
 function neotest.lib.subprocess.add_paths_to_rtp(paths)
   local rtp = nio.fn.rpcrequest(child_chan, "nvim_get_option_value", "runtimepath", {})
   for _, path in ipairs(paths) do
-    rtp = rtp .. "," .. path
+    if type(path) == "function" then
+      local ok, root = pcall(neotest.lib.subprocess.resolve_plugin_root, path)
+      if ok and root then
+        path = root
+      else
+        path = nil
+      end
+    end
+    if path then
+      rtp = rtp .. "," .. path
+    end
   end
   logger.debug("Setting rtp in subprocess", rtp)
   nio.fn.rpcrequest(child_chan, "nvim_set_option_value", "runtimepath", rtp, {})

--- a/lua/neotest/lib/subprocess.lua
+++ b/lua/neotest/lib/subprocess.lua
@@ -66,10 +66,6 @@ function neotest.lib.subprocess.init()
       require("nio").sleep,
       require("plenary.path").new,
     }
-    local has_ts, ts = pcall(require, "nvim-treesitter")
-    if has_ts and ts.setup then
-      table.insert(plugin_funcs, ts.setup)
-    end
 
     for _, plugin_func in ipairs(plugin_funcs) do
       local root = neotest.lib.subprocess.resolve_plugin_root(plugin_func)
@@ -170,17 +166,7 @@ end
 function neotest.lib.subprocess.add_paths_to_rtp(paths)
   local rtp = nio.fn.rpcrequest(child_chan, "nvim_get_option_value", "runtimepath", {})
   for _, path in ipairs(paths) do
-    if type(path) == "function" then
-      local ok, root = pcall(neotest.lib.subprocess.resolve_plugin_root, path)
-      if ok and root then
-        path = root
-      else
-        path = nil
-      end
-    end
-    if path then
-      rtp = rtp .. "," .. path
-    end
+    rtp = rtp .. "," .. path
   end
   logger.debug("Setting rtp in subprocess", rtp)
   nio.fn.rpcrequest(child_chan, "nvim_set_option_value", "runtimepath", rtp, {})

--- a/tests/unit/lib/files/init_spec.lua
+++ b/tests/unit/lib/files/init_spec.lua
@@ -6,6 +6,17 @@ A = function(...)
 end
 
 describe("files library", function()
+  describe("path normalization", function()
+    it("normalizes path on windows or leaves untouched on unix", function()
+      if vim.fn.has("win32") == 1 then
+        assert.equal("C:\\foo\\bar", files.path.normalize("c:/foo/bar"))
+        assert.equal("D:\\test\\file.lua", files.path.normalize("d:\\test/file.lua"))
+      else
+        assert.equal("/root/test_a", files.path.normalize("/root/test_a"))
+      end
+    end)
+  end)
+
   describe("parsing directory tree from files", function()
     it("places files under the root", function()
       local root = "/root"


### PR DESCRIPTION
> Transparency note: I'm a Windows user who ran into these issues while using neotest with neotest-java. I don't have deep knowledge of the neotest codebase — I used an AI coding agent (Google Antigravity) to help diagnose and fix these problems. The fixes work on my setup, but I'd appreciate maintainers reviewing whether the approach is sound and if there are edge cases I may have missed. Happy to adjust anything based on feedback.

Below is a brief explanation of the problem and the proposed fix.

## Problem

On Windows, neotest has path normalization issues that cause position lookups and watch mode failures:

### 1. Drive letter casing mismatch breaks path lookups

Neovim APIs return paths with inconsistent drive letter casing. For example, `vim.fn.expand("%:p")` may return `e:\projects\...` while `vim.fn.getcwd()` returns `E:\projects\...`. Since Lua's string comparison is case-sensitive, `vim.startswith()` checks and tree key lookups fail silently — neotest can't find positions, can't match buffers to test trees, and reports "No tests found" even though the files exist.

**Affected code paths:**
- `Client:get_position()` — position ID lookup fails
- `Client:_update_positions()` — position discovery fails
- `path.real()` — file existence checks fail

### 2. Watch consumer can't find LSP clients

`get_lsp_client()` in `watch/init.lua` compares buffer paths from `nvim_buf_get_name()` against tree keys. On Windows, the drive letter casing mismatch causes `tree:get_key(path)` to always return `nil`, so the watcher reports "No valid LSP client found" and watch mode silently breaks.

The same issue occurs in `watcher.lua` where `_get_linked_files()` and the `BufWritePost` autocmd handler compare buffer paths against dependency URIs and tree data paths.

### ~~3. Subprocess crashes when `add_paths_to_rtp` receives function objects~~ *(Reverted per review)*

~~When adapters add entries to the subprocess runtime path via `add_paths_to_rtp()`, some adapter paths are actually function objects (e.g., `is_test_file` overrides) rather than path strings. The original code unconditionally concatenated them with `rtp = rtp .. "," .. path`, causing a Lua type error crash in the subprocess.~~

~~Additionally, the nvim-treesitter plugin root was not being added to the subprocess `rtp` during initialization, which could cause Treesitter parser resolution to fail in the child process.~~

---

## Solution

### Centralized path normalization

Added `neotest.lib.files.path.normalize(path)` in `lib/file/init.lua`:
- Uppercases the drive letter (`e:` → `E:`)  
- Converts forward slashes to backslashes (`/` → `\`)
- Only active on `win32`, no-op on other platforms
- Guards against non-string input

Applied `normalize()` at every boundary where paths enter from Neovim APIs:
- `Client:get_position()` — normalizes `position_id` before lookup
- `Client:_update_positions()` — normalizes `path` before discovery
- `get_lsp_client()` — normalizes buffer path before tree key lookup
- `Watcher:_get_linked_files()` — normalizes path and URI-derived paths
- `Watcher:watch()` BufWritePost handler — normalizes buffer path and tree data path before comparison
- `path.real()` — normalizes the result of `fnamemodify`

### ~~Subprocess rtp safety~~ *(Reverted per review)*

~~Fixed `add_paths_to_rtp()` in `lib/subprocess.lua`:~~
- ~~If a path entry is a `function`, attempt to resolve it to a plugin root directory via `resolve_plugin_root()`~~
- ~~If resolution fails, skip the entry instead of crashing~~
- ~~Added `nvim-treesitter` setup function to `plugin_funcs` so the Treesitter plugin root is included in the subprocess rtp~~

---

## Files Changed

| File | Change |
|------|--------|
| `lua/neotest/lib/file/init.lua` | Added `normalize()` to `path` utilities; applied in `path.real()` |
| `lua/neotest/client/init.lua` | Normalize paths in `get_position()` and `_update_positions()` |
| `lua/neotest/consumers/watch/init.lua` | Normalize buffer path in `get_lsp_client()` |
| `lua/neotest/consumers/watch/watcher.lua` | Normalize paths in `_get_linked_files()` and BufWritePost handler |
| `tests/unit/lib/files/init_spec.lua` | Added unit tests for `neotest.lib.files.path.normalize()` |
| ~~`lua/neotest/lib/subprocess.lua`~~ | ~~Handle function entries in `add_paths_to_rtp()`; add nvim-treesitter to subprocess rtp~~ *(Reverted)* |

---

## Testing

- Added unit tests in `tests/unit/lib/files/init_spec.lua` testing drive casing and path separator normalization.
- Tested manually on Windows 11 and WSL2 with:
  - Neovim `0.12`, LazyVim
  - `neotest-java` adapter with a Maven project
  - Verified test discovery, position lookups, and watch mode all work with mixed-case drive letter paths

---

## Related Issues

- ~~Partially addresses #268 — `[BUG] no such file or directory, when running test on Windows`~~ *(Reverted)*
- Related to [#563](https://github.com/nvim-neotest/neotest/issues/563) — `[BUG] No tests found on Windows` (resolves drive letter casing mismatch during path lookups)

---

## Disclosure

Co-authored with AI coding assistant (Google Antigravity).