### PR TITLE
fix(ci): repair invalid docgen workflow trigger

### DIFF
--- a/.github/workflows/docgen.yaml
+++ b/.github/workflows/docgen.yaml
@@ -1,11 +1,8 @@
 # Taken from telescope
 name: Generate docs
 
-# on:
-#   push:
-#     branches-ignore:
-#       - master
-#   pull_request: ~
+on:
+  workflow_dispatch: {}
 
 jobs:
   build-sources:


### PR DESCRIPTION
docgen.yaml's on: block was fully commented out to disable it, but a workflow with no on: key is invalid and GitHub records a failed run for it on every push to master. Giving it a real workflow_dispatch trigger keeps it inert (no auto-runs) while making the file valid again.