### PR TITLE
fix(ci): use full checkout depth in luarocks-upload job

### DIFF
--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -84,7 +84,9 @@ jobs:
     needs: release
     steps:
       - uses: actions/checkout@v5
-      - name: Get Version 
+        with:
+          fetch-depth: 0
+      - name: Get Version
         run: echo "LUAROCKS_VERSION=$(git fetch --tags; git describe --abbrev=0 --tags)" >> $GITHUB_ENV
       - name: LuaRocks Upload
         uses: nvim-neorocks/luarocks-tag-release@v7


### PR DESCRIPTION
luarocks-upload shallow-clones (default depth 1), so git describe --tags can only resolve when the pushed commit is itself freshly tagged by the release job. On pushes that don't cut a new semantic-release version (e.g. docs-only commits), describe fails, LUAROCKS_VERSION ends up empty, and the generated rockspec's invalid "-1" version gets rejected by LuaRocks. fetch-depth: 0 lets describe walk back to the last reachable tag regardless of whether this push released.