### PR TITLE
ci: restrict workflow.yaml to auto-run only on nvim-neotest

### DIFF
--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -4,9 +4,11 @@ on:
     branches:
       - master
   pull_request: ~
+  workflow_dispatch: {}
 jobs:
   style:
     name: style
+    if: ${{ github.repository == 'nvim-neotest/neotest' || github.event_name == 'workflow_dispatch' }}
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v5
@@ -18,6 +20,7 @@ jobs:
 
   tests:
     name: tests
+    if: ${{ github.repository == 'nvim-neotest/neotest' || github.event_name == 'workflow_dispatch' }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -60,7 +63,7 @@ jobs:
 
   release:
     name: release
-    if: ${{ github.ref == 'refs/heads/master' }}
+    if: ${{ (github.repository == 'nvim-neotest/neotest' || github.event_name == 'workflow_dispatch') && github.ref == 'refs/heads/master' }}
     needs:
       - style
       - tests
@@ -80,6 +83,7 @@ jobs:
         run: npx semantic-release
 
   luarocks-upload:
+    if: ${{ github.repository == 'nvim-neotest/neotest' || github.event_name == 'workflow_dispatch' }}
     runs-on: ubuntu-22.04
     needs: release
     steps:


### PR DESCRIPTION
Pushing branches to a personal fork was triggering these jobs (and, in release/luarocks-upload's case, failing them outright since forks don't carry the release/publish secrets). Gate push/pull_request-triggered runs behind github.repository so they only fire automatically on the main org repo, and add workflow_dispatch so a fork owner can still run the pipeline manually when they want to.