### PR TITLE
Prevent buffer processing if that buffer represents the contents of a directory

### DIFF
--- a/lua/neotest/client/init.lua
+++ b/lua/neotest/client/init.lua
@@ -502,6 +502,10 @@ function neotest.Client:_start(args)
       return
     end
 
+    if vim.uv.fs_stat(path).type == "directory" then
+      return
+    end
+
     nio.run(function()
       local pos, pos_adapter_id = self:get_nearest(path, line - 1)
       if not pos then


### PR DESCRIPTION
- for instance, using a filesystem plugin like vim-dirvish

This change prevents untimely error message notification coming from the execution of `self:get_nearest` when the user enters a buffer that represents a directory content instead of a file content

<img width="1242" height="244" alt="image" src="https://github.com/user-attachments/assets/c8f08ccb-8cc6-483b-8d9a-6a1d07f9a00b" />
