### PR TITLE
feat(treesitter): support match_limit in parse options

### DIFF
--- a/doc/neotest.txt
+++ b/doc/neotest.txt
@@ -1392,6 +1392,11 @@ are needed)
 table<string, userdata>, metadata: table<string,
 vim.treesitter.query.TSMetadata>): neotest.Position|neotest.Position[]|nil)`
 Builds one or more positions from the captured nodes from a query match.
+{match_limit?} `(integer)` Maximum number of in-progress matches for the
+tree-sitter query cursor (Neovim's default is 256). When the limit is
+exceeded, the earliest-starting matches are silently dropped, which can hide
+positions in large files (e.g. long table-driven tests). Requires Neovim
+0.10+; ignored on older versions.
 
                                       *neotest.lib.treesitter.normalise_query()*
 `normalise_query`({lang}, {query})

--- a/lua/neotest/lib/treesitter/init.lua
+++ b/lua/neotest/lib/treesitter/init.lua
@@ -56,7 +56,9 @@ local function collect(file_path, query, source, root, opts)
       range = { root:range() },
     },
   }
-  for _, match, metadata in query:iter_matches(root, source, nil, nil) do
+  for _, match, metadata in
+    query:iter_matches(root, source, nil, nil, { match_limit = opts.match_limit })
+  do
     local captured_nodes = {}
     local node_metadata = {}
     for i, capture in ipairs(query.captures) do
@@ -93,6 +95,7 @@ end
 ---@class neotest.lib.treesitter.ParseOptions : neotest.lib.positions.ParseOptions
 ---@field fast? boolean Use faster parsing (Should be unchanged unless injections are needed)
 ---@field build_position? fun(file_path: string, source: string, captured_nodes: table<string, userdata>, metadata: table<string, vim.treesitter.query.TSMetadata>): neotest.Position|neotest.Position[]|nil Builds one or more positions from the captured nodes from a query match.
+---@field match_limit? integer Maximum number of in-progress matches for the tree-sitter query cursor (Neovim's default is 256). When the limit is exceeded, the earliest-starting matches are silently dropped, which can hide positions in large files (e.g. long table-driven tests). Requires Neovim 0.10+; ignored on older versions.
 
 --- Build a parsed Query object from a string
 ---@param lang string

--- a/tests/unit/lib/treesitter/match_limit_spec.lua
+++ b/tests/unit/lib/treesitter/match_limit_spec.lua
@@ -1,0 +1,60 @@
+local nio = require("nio")
+local a = nio.tests
+local lib = require("neotest.lib")
+
+describe("lib.treesitter.parse_positions_from_string with match_limit", function()
+  local file_path = "/match_limit_test.lua"
+  -- Binding every function to the single trailing return_statement keeps each
+  -- match in progress until the end of the chunk, so the query cursor's
+  -- match buffer fills up and evicts the earliest-starting matches once its
+  -- limit is exceeded.
+  local query = [[
+(chunk
+  (function_declaration name: (identifier) @test.name) @test.definition
+  (return_statement))
+]]
+
+  local function build_test_content()
+    local lines = {}
+    for i = 1, 400 do
+      local name = string.format("test_%03d", i)
+      table.insert(lines, string.format("local function %s() end", name))
+    end
+    table.insert(lines, "return true")
+    return table.concat(lines, "\n")
+  end
+
+  local function collect_test_names(tree)
+    local names = {}
+    for _, pos in tree:iter() do
+      if pos.type == "test" then
+        table.insert(names, pos.name)
+      end
+    end
+    return names
+  end
+
+  a.it("detects all positions when match_limit is raised", function()
+    local content = build_test_content()
+    local opts = { match_limit = 1024 }
+
+    local tree = lib.treesitter.parse_positions_from_string(file_path, content, query, opts)
+    local names = collect_test_names(tree)
+
+    assert.are.equal(400, #names)
+    assert.are.equal("test_001", names[1])
+    assert.are.equal("test_400", names[#names])
+  end)
+
+  a.it("forwards match_limit to the query cursor", function()
+    local content = build_test_content()
+    local opts = { match_limit = 8 }
+
+    local tree = lib.treesitter.parse_positions_from_string(file_path, content, query, opts)
+    local names = collect_test_names(tree)
+
+    assert.is_true(#names < 400)
+    assert.are.equal("test_400", names[#names])
+    assert.is_not.equal("test_001", names[1])
+  end)
+end)


### PR DESCRIPTION
## Why?

It all begun with this being filed: https://github.com/fredrikaverpil/neotest-golang/issues/581

- Tree-sitter query cursors keep in-progress matches in a bounded buffer — Neovim defaults it to 256 ([`Query:iter_matches()`](https://neovim.io/doc/user/treesitter.html#Query%3Aiter_matches()), introduced in [neovim/neovim#14915](https://github.com/neovim/neovim/pull/14915)) - and on overflow the *earliest-starting* match is silently dropped, per the documented behaviour of [`ts_query_cursor_set_match_limit`](https://github.com/tree-sitter/tree-sitter/blob/master/lib/include/tree_sitter/api.h): *"If this capacity is exceeded, then the earliest-starting match will silently be dropped to make room for further matches."*
- Queries whose patterns bind early nodes to a trailing sibling accumulate in-progress matches, so positions at the top of large files silently disappear during discovery.
- In neotest-golang, the [table-test queries](https://github.com/fredrikaverpil/neotest-golang/tree/61726ad/lua/neotest-golang/queries/go) bind every struct element to the trailing `for ... t.Run(...)` loop, so with too many table test cases the earliest ones silently vanish - in a 100-case table, discovery starts at case 058 ([fredrikaverpil/neotest-golang#581](https://github.com/fredrikaverpil/neotest-golang/issues/581)).
- neotest currently calls [`query:iter_matches(root, source, nil, nil)`](https://github.com/nvim-neotest/neotest/blob/4e2cd42/lua/neotest/lib/treesitter/init.lua#L59) with no way for adapters to raise the limit.

```go
// 100 cases; every element stays an in-progress match until the trailing loop.
testCases := []struct{ name, content string }{
    {name: "case 001", content: "x"}, // dropped
    // ... first 57 dropped
    {name: "case 058", content: "x"}, // first detected
}
for _, tc := range testCases {
    t.Run(tc.name, func(t *testing.T) { /* ... */ })
}
```

## What?

- Add `match_limit?: integer` to [`neotest.lib.treesitter.ParseOptions`](https://github.com/nvim-neotest/neotest/blob/4e2cd42/lua/neotest/lib/treesitter/init.lua#L93), forwarded to [`Query:iter_matches`](https://neovim.io/doc/user/treesitter.html#Query%3Aiter_matches()). Adapters opt in via their existing [`parse_positions`](https://github.com/nvim-neotest/neotest/blob/4e2cd42/lua/neotest/lib/treesitter/init.lua#L171) opts; the integer serializes fine through subprocess parsing. Neovim < 0.10 ignores the extra argument.
- [Regression spec](https://github.com/fredrikaverpil/neotest/blob/802264d/tests/unit/lib/treesitter/match_limit_spec.lua) proving a raised limit finds all positions and a low limit drops the earliest ones.

## Notes

- Verified against neotest-golang: with the default limit, 43 of 100 table test cases were detected; with `match_limit = 4096` passed through `parse_positions` opts, all 100 -- including through the subprocess round-trip.
- I'd like to see what I can do about this on the neotest-golang side, but so far every adapter-side workaround has required adding a lot of complexity - this option gives adapters a one-line escape hatch instead.
- Raising the limit moves the ceiling rather than removing it, and per the tree-sitter docs a higher limit costs memory per cursor - so this is deliberately opt-in per adapter rather than a raised default.